### PR TITLE
Refactor predict refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Make an output folder `output_folder_name` and run `main.py` with arguments of y
 ```
 mkdir -p /tmp/parser-output/output_folder_name
 
-python3 $DIR/main.py \
+python3 main.py \
 	--scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
 	--references-file "match-references/MRC_Publications_Nov2018_JGHT_JHSRI.csv" \
 	--model-file "s3://datalabs-data/reference_parser_models/RefSorter_classifier.pkl" \

--- a/main.py
+++ b/main.py
@@ -85,9 +85,13 @@ def run_predict(scraper_file, references_file,
     )
     
     # Link predictions back with all original data (Document id etc)
+    # When we merge and splited_references is a dict not a dataframe then we could just merge the list of dicts
     reference_components_predictions = splited_references
-    reference_components_predictions["Predicted Category"] = [tup[0] for tup in components_predictions]
-    reference_components_predictions["Prediction Probability"] = [tup[1] for tup in components_predictions]
+    reference_components_predictions["Predicted Category"] = (
+        [components_prediction["Predicted Category"] for components_prediction in components_predictions]
+        )
+    reference_components_predictions["Prediction Probability"] = (
+        [components_prediction["Prediction Probability"] for components_prediction in components_predictions])
     
     # Predict the reference structure????
     predicted_reference_structures = predict_structure(

--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ def run_predict(scraper_file, references_file,
         splitted_components = process_references(splitted_references)
 
         # Predict the references types (eg title/author...)
-        logger.info('[+] Predicting the reference components')
+        # logger.info('[+] Predicting the reference components')
         components_predictions = predict_references(
             pool_map,
             mnb,

--- a/main.py
+++ b/main.py
@@ -78,12 +78,17 @@ def run_predict(scraper_file, references_file,
 
     # Predict the references types (eg title/author...)
     logger.info('[+] Predicting the reference components')
-    reference_components_predictions = predict_references(
+    components_predictions = predict_references(
         mnb,
         vectorizer,
-        splited_references
+        splited_references['Reference component']
     )
-
+    
+    # Link predictions back with all original data (Document id etc)
+    reference_components_predictions = splited_references
+    reference_components_predictions["Predicted Category"] = [tup[0] for tup in components_predictions]
+    reference_components_predictions["Prediction Probability"] = [tup[1] for tup in components_predictions]
+    
     # Predict the reference structure????
     predicted_reference_structures = predict_structure(
         reference_components_predictions,

--- a/main.py
+++ b/main.py
@@ -87,11 +87,12 @@ def run_predict(scraper_file, references_file,
     # Link predictions back with all original data (Document id etc)
     # When we merge and splited_references is a dict not a dataframe then we could just merge the list of dicts
     reference_components_predictions = splited_references
-    reference_components_predictions["Predicted Category"] = (
-        [components_prediction["Predicted Category"] for components_prediction in components_predictions]
-        )
-    reference_components_predictions["Prediction Probability"] = (
-        [components_prediction["Prediction Probability"] for components_prediction in components_predictions])
+    reference_components_predictions["Predicted Category"] = [
+        d["Predicted Category"] for d in components_predictions
+    ]
+    reference_components_predictions["Prediction Probability"] = [
+        d["Prediction Probability"] for d in components_predictions
+    ]
     
     # Predict the reference structure????
     predicted_reference_structures = predict_structure(

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -21,7 +21,10 @@ class TestPredict(unittest.TestCase):
 		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
 		all_categories = ['Authors', 'Title', 'Journal', 'PubYear', 'Volume', 'Issue', 'Pagination']
 		self.assertEqual(
-			isinstance(components_predictions, list) and
+			isinstance(components_predictions, list),
+			True, "Should be a list"
+			)
+		self.assertEqual(
 			all([components_prediction[0] in all_categories for components_prediction in components_predictions]),
 			True, "Should be a list of categories from {}".format(all_categories)
 			)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -4,7 +4,7 @@ import pickle
 
 from utils import predict_references
 
-MODELS_DIR = os.path.join( os.path.dirname(__file__), '..', 'reference_parser_models')
+MODELS_DIR = os.path.join(os.path.dirname(__file__), '..', 'reference_parser_models')
 
 with open(os.path.join(MODELS_DIR, "RefSorter_classifier.pkl"), "rb") as f:
     mnb = pickle.load(f)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -14,31 +14,31 @@ with open(os.path.join(MODELS_DIR, "RefSorter_vectorizer.pkl"), "rb") as f:
 
 class TestPredict(unittest.TestCase):
 	def test_empty_components(self):
-		components_predictions = predict_references(mnb,vectorizer,[])
+		components_predictions = predict_references(map,mnb,vectorizer,[])
 		self.assertEqual(components_predictions, [], "Should be []")
 
 	def test_normal_components(self):
-		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
+		components_predictions = predict_references(map,mnb,vectorizer,["Component","Component","Component"])
 		all_categories = ['Authors', 'Title', 'Journal', 'PubYear', 'Volume', 'Issue', 'Pagination']
 		self.assertEqual(
 			isinstance(components_predictions, list),
 			True, "Should be a list"
 			)
 		self.assertEqual(
-			all([components_prediction[0] in all_categories for components_prediction in components_predictions]),
+			all([components_prediction['Predicted Category'] in all_categories for components_prediction in components_predictions]),
 			True, "Should be a list of categories from {}".format(all_categories)
 			)
 
 	def test_size(self):
-		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
+		components_predictions = predict_references(map,mnb,vectorizer,["Component","Component","Component"])
 		self.assertEqual(len(components_predictions) , 3, "Should be 3")
 
 	def test_string_component(self):
-		components_predictions = predict_references(mnb,vectorizer,["Component"])
-		self.assertEqual(isinstance(components_predictions[0][0], str), True, "Should be a string")
+		components_predictions = predict_references(map,mnb,vectorizer,["Component"])
+		self.assertEqual(isinstance(components_predictions[0]['Predicted Category'], str), True, "Should be a string")
 
 	def test_year_component(self):
-		components_predictions = predict_references(mnb,vectorizer,["1999"])
-		self.assertEqual(components_predictions[0][0], 'PubYear', "Should be 'PubYear'")
+		components_predictions = predict_references(map,mnb,vectorizer,["1999"])
+		self.assertEqual(components_predictions[0]['Predicted Category'], 'PubYear', "Should be 'PubYear'")
 
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,32 +1,41 @@
+import os.path
 import unittest
+import pickle
 
 from utils import predict_references
 
-import pickle
+MODELS_DIR = os.path.join( os.path.dirname(__file__), '..', 'reference_parser_models')
 
-pickle_in = open("./reference_parser_models/RefSorter_classifier.pkl","rb")
-mnb = pickle.load(pickle_in)
+with open(os.path.join(MODELS_DIR, "RefSorter_classifier.pkl"), "rb") as f:
+    mnb = pickle.load(f)
 
-pickle_in = open("./reference_parser_models/RefSorter_vectorizer.pkl","rb")
-vectorizer = pickle.load(pickle_in)
+with open(os.path.join(MODELS_DIR, "RefSorter_vectorizer.pkl"), "rb") as f:
+    vectorizer = pickle.load(f)
 
-class TestSplit(unittest.TestCase):
+class TestPredict(unittest.TestCase):
 	def test_empty_components(self):
-		components_predictions = predict_references(mnb,vectorizer,"")
+		components_predictions = predict_references(mnb,vectorizer,[])
 		self.assertEqual(components_predictions, [], "Should be []")
 
 	def test_normal_components(self):
 		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
-		self.assertEqual(isinstance(components_predictions, list) , True, "Should be a list")
+		all_categories = ['Authors', 'Title', 'Journal', 'PubYear', 'Volume', 'Issue', 'Pagination']
+		self.assertEqual(
+			isinstance(components_predictions, list) and
+			all([components_prediction[0] in all_categories for components_prediction in components_predictions]),
+			True, "Should be a list of categories from {}".format(all_categories)
+			)
 
 	def test_size(self):
 		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
 		self.assertEqual(len(components_predictions) , 3, "Should be 3")
 
-	def test_author_component(self):
+	def test_string_component(self):
 		components_predictions = predict_references(mnb,vectorizer,["Component"])
 		self.assertEqual(isinstance(components_predictions[0][0], str), True, "Should be a string")
 
 	def test_year_component(self):
 		components_predictions = predict_references(mnb,vectorizer,["1999"])
 		self.assertEqual(components_predictions[0][0], 'PubYear', "Should be 'PubYear'")
+
+

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,32 @@
+import unittest
+
+from utils import predict_references
+
+import pickle
+
+pickle_in = open("./reference_parser_models/RefSorter_classifier.pkl","rb")
+mnb = pickle.load(pickle_in)
+
+pickle_in = open("./reference_parser_models/RefSorter_vectorizer.pkl","rb")
+vectorizer = pickle.load(pickle_in)
+
+class TestSplit(unittest.TestCase):
+	def test_empty_components(self):
+		components_predictions = predict_references(mnb,vectorizer,"")
+		self.assertEqual(components_predictions, [], "Should be []")
+
+	def test_normal_components(self):
+		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
+		self.assertEqual(isinstance(components_predictions, list) , True, "Should be a list")
+
+	def test_size(self):
+		components_predictions = predict_references(mnb,vectorizer,["Component","Component","Component"])
+		self.assertEqual(len(components_predictions) , 3, "Should be 3")
+
+	def test_author_component(self):
+		components_predictions = predict_references(mnb,vectorizer,["Component"])
+		self.assertEqual(isinstance(components_predictions[0][0], str), True, "Should be a string")
+
+	def test_year_component(self):
+		components_predictions = predict_references(mnb,vectorizer,["1999"])
+		self.assertEqual(components_predictions[0][0], 'PubYear', "Should be 'PubYear'")

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -145,6 +145,9 @@ def predict_structure(reference_components_predictions,
     each reference for each document in turn.
     """
 
+    # Convert to pd dataframe, although when this function is refactored we shouldnt have to do this
+    reference_components_predictions = pd.DataFrame.from_dict(reference_components_predictions)
+
     all_structured_references = []
     document_ids = set(reference_components_predictions['Document id'])
 

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -284,10 +284,10 @@ def predict_references(pool_map, mnb,
     """
     Predicts the categories for a list of reference components.
     Input:
+    - pool_map: Pool map used for multiprocessing the predicting
     - mnb: The trained multinomial naive Bayes model for predicting the categories of reference components
     - vectorizer: The vector of word counts in the training set
     - reference_components: A list of reference components
-    - num_workers: How many different processors you want to use in multiprocessing the predicting
     Output:
     - A list of dicts [{"Predicted Category": , "Prediction Probability": } ...]
     """

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -242,22 +242,6 @@ def _get_component(component, mnb, vectorizer):
             'Prediction Probability': pred_prob
             }
 
-def dict_to_tuples(list_dict):
-    """
-    Input: List of dicts
-    Output: List of tuples
-    """
-
-    list_tuples = []
-    for dic in list_dict:
-        tup = ()
-        for key,val in dic.items():
-            tup = (*tup,val)
-        list_tuples.append(tup)
-
-    return list_tuples
-
-
 def predict_references(mnb,
                        vectorizer,
                        reference_components,
@@ -299,8 +283,6 @@ def predict_references(mnb,
         reference_components
     ))
 
-    components_predictions = dict_to_tuples(predict_all)
-
     logger.info("Predictions complete")
-    return components_predictions
+    return [tuple(d.values()) for d in predict_all]
 

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -255,7 +255,7 @@ def predict_references(mnb,
     - reference_components: A list of reference components
     - num_workers: How many different processors you want to use in multiprocessing the predicting
     Output:
-    - A list of tuples ("Predicted Category", "Prediction Probability")
+    - A list of dicts [{"Predicted Category": , "Prediction Probability": } ...]
     """
 
     logger.info(
@@ -284,5 +284,6 @@ def predict_references(mnb,
     ))
 
     logger.info("Predictions complete")
-    return [tuple(d.values()) for d in predict_all]
+
+    return predict_all
 

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -3,7 +3,6 @@ from functools import partial
 from settings import settings
 from multiprocessing import Pool
 
-import pickle
 logger = settings.logger
 
 


### PR DESCRIPTION
# Description

This PR:

- Rewrites `predict_references` so that it doesn't use pandas
- Rewrites `predict_references` so that it inputs a list of components and outputs a list of tuples (prediction, probability)
- Introduces some tests for `predict_references`
- Adds a line at the beginning of `predict_structure` so that the new input (which is now a dictionary) is converted to a pd dataframe, so that this function continues to work. The aim is to eventually (in a different PR) refactor `predict_structure` so that it doesn't require a pd dataframe input, so eventually this will be redundant.
- `main` had to be updated in order to get the new output of `predict_references` into the correct format for the rest of the code.
- Fixes a small error in the README

# How Has This Been Tested?

`test_predict.py` file has been added in the tests folder. You can run those tests by running `python -m unittest tests.test_predict` while on the root directory.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
