### PR TITLE
Fix #41 to deal with case of Title prediction

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -40,6 +40,8 @@ class BaseSettings:
     }
     ORGANISATION_REGEX = _regex_dict.get(ORGANISATION, "\n")
 
+    REF_CLASSES = ['Authors', 'Journal', 'Volume', 'Issue', 'Pagination', 'Title','PubYear']
+
 
 class ProdSettings(BaseSettings):
     DEBUG = False

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -71,10 +71,11 @@ def decide_components(single_reference):
     single_reference = pd.concat([single_reference, block_number], axis=1)
     single_reference_components = {}
 
-    for classes in set(single_reference["Predicted Category"]):
+    categories =  settings.REF_CLASSES
+    for category in categories:
 
         # Are there any sentences of this type (i.e. Authors, Title)?
-        classornot = sum(single_reference['Predicted Category'] == classes)
+        classornot = sum(single_reference['Predicted Category'] == category)
 
         if classornot != 0:
 
@@ -82,18 +83,18 @@ def decide_components(single_reference):
             number_blocks = len(
                 single_reference['Block'][single_reference[
                     'Predicted Category'
-                ] == classes].unique()
+                ] == category].unique()
             )
 
             if number_blocks == 1:
                 # Just record this block separated by commas
                 single_reference_components.update({
-                    classes: ", ".join(
+                    category: ", ".join(
                         single_reference[
                             'Reference component'
                         ][single_reference[
                             'Predicted Category'
-                        ] == classes]
+                        ] == category]
                     )
                 })
             else:
@@ -104,7 +105,7 @@ def decide_components(single_reference):
                 # (random choice)
                 
                 highest_probability_index = single_reference[
-                    single_reference['Predicted Category'] == classes
+                    single_reference['Predicted Category'] == category
                 ]['Prediction Probability'].idxmax()
 
                 highest_probability_block = single_reference[
@@ -113,7 +114,7 @@ def decide_components(single_reference):
 
                 # Use everything in this block, separated by comma
                 single_reference_components.update({
-                    classes: ", ".join(
+                    category: ", ".join(
                         single_reference[
                             "Reference component"
                         ][single_reference[
@@ -123,7 +124,7 @@ def decide_components(single_reference):
                 })
         else:
             # There are none of this classification, append with blank
-            single_reference_components.update({classes: ""})
+            single_reference_components.update({category: ""})
 
     return single_reference_components
 


### PR DESCRIPTION
Fix for https://github.com/wellcometrust/reference-parser/issues/41

# Description

Small change to `predict.py` and `settings.py` to make output contain all categories even if nothing is predicted for any of them. As in the case where no matched references are found, a file called `all_match_data.csv` is still outputted, but it will be empty.

This looks like more changes than there were due to a tab change.

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

It hasn't.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
