### PR TITLE
Fix the attribute error logged by sentry

### DIFF
--- a/wsf-scraper-web/pdf_parser/pdf_parse.py
+++ b/wsf-scraper-web/pdf_parser/pdf_parse.py
@@ -37,7 +37,7 @@ def parse_pdf_document(document):
             document.name,
             e.stderr,
         )
-        return None, None
+        return None
 
     try:
         # Try to get file stats in order to check both its existance
@@ -49,13 +49,13 @@ def parse_pdf_document(document):
             raise
 
         logger.warning('Error trying to open the parsed file: %s', e)
-        return None, None
+        return None
 
     if st.st_size == 0:
         logger.warning(
             'Error trying to open the parsed file: The file is empty'
         )
-        return None, None
+        return None
 
     with open(parsed_path, 'rb') as html_file:
         soup = bs(html_file.read(), 'html.parser')


### PR DESCRIPTION
# Description

The pdf parseer module returning a tuple allowed to pass the
verification for an empty pdf, as `1 if (None, None) else 2` returns 1.

Fixed this by removing the old tuple returns to make them return None
instead.

Fix #52 

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Local runs, unittests (Python3.6)
