### PR TITLE
Merge match results from multiple documents and organisations

### DIFF
--- a/merge_results.py
+++ b/merge_results.py
@@ -4,6 +4,7 @@ Manually edit main with the folder names you want to merge all together
 Output is one csv of all the matches from all the organisations you have provided
 """
 
+from argparse import ArgumentParser
 import fnmatch
 import os
 import glob
@@ -27,7 +28,7 @@ def get_csv_names(file_dir, suffix):
 
     return csv_names
 
-def merge_match_csvs(match_csv_names):
+def concat_match_csvs(match_csv_names):
     """
     This function merges all the csvs given in match_csv_names
     Input:
@@ -41,12 +42,12 @@ def merge_match_csvs(match_csv_names):
         if not match_data.empty:
             all_matches.append(match_data)
 
-    all_matches = pd.concat(all_matches, ignore_index=False)
+    all_matches = pd.concat(all_matches)
 
     return all_matches
 
 
-def merge_predicted_csvs(predicted_csv_names):
+def concat_predicted_csvs(predicted_csv_names):
     """
     This function gets all the document id & document url from the predicted references csv
     Input:
@@ -70,21 +71,35 @@ def merge_predicted_csvs(predicted_csv_names):
 
     return all_url
 
+def create_argparser(description):
+    parser = ArgumentParser(description)
+    parser.add_argument(
+        '--file_dir',
+        help='Directory of saved output folders',
+        default = './tmp/parser-output/charlene'
+    )
+    parser.add_argument(
+        '--match_refs_file',
+        help='Original references file which was used in parsing of saved outputs',
+        default = './match-references/charlene_publications_format.csv'
+    )
+    return parser
+
 if __name__ == '__main__':
 
-    file_dir = './tmp/parser-output/charlene' # "pophealth", "charlene"
-    output_name = 'merged_all_matches'
+    parser = create_argparser(__doc__.strip())
+    args = parser.parse_args()
+
+    file_dir = args.file_dir
+    output_folder_name = 'merged_all_matches'
     
-    match_refs = pd.read_csv(
-        "./match-references/charlene_publications_format.csv")
-    # "./match-references/MRC_Publications_Nov2018_JGHT_JHSRI_all.csv"
-    # "./match-references/charlene_publications_format.csv"
+    match_refs = pd.read_csv(args.match_refs_file)
 
     match_csv_names = get_csv_names(file_dir, '_all_match_data')
     predicted_csv_names = get_csv_names(file_dir, '_predicted_reference_structures')
 
-    all_match = merge_match_csvs(match_csv_names)
-    all_url = merge_predicted_csvs(predicted_csv_names)
+    all_match = concat_match_csvs(match_csv_names)
+    all_url = concat_predicted_csvs(predicted_csv_names)
 
     all_matches_url = all_match.join(
         all_url.set_index('Document id'),
@@ -96,9 +111,9 @@ if __name__ == '__main__':
         on='WT_Ref_Id'
         ) # Join with references information
 
-    if not os.path.exists('{}/{}'.format(file_dir, output_name)):
-            os.makedirs('{}/{}'.format(file_dir, output_name))
+    if not os.path.exists('{}/{}'.format(file_dir, output_folder_name)):
+            os.makedirs('{}/{}'.format(file_dir, output_folder_name))
 
-    all_matches_refs.to_csv('{}/{}/merged_all_matches.csv'.format(file_dir, output_name))
+    all_matches_refs.to_csv('{}/{}/merged_all_matches.csv'.format(file_dir, output_folder_name))
 
 

--- a/merge_results.py
+++ b/merge_results.py
@@ -1,0 +1,70 @@
+"""
+This code is used to merge the matched results together after running the parser
+Manually edit main with the folder names you want to merge all together
+Output is one csv of all the matches from all the organisations you have provided
+"""
+
+import os
+import pandas as pd
+
+def get_matches(all_matches, all_uri, file_dir):
+    """
+    Read all the match files from a file directory
+    Append any matches found to all_matches
+    If there is a match then append the uri to all_uri
+    """
+    for file in os.listdir(file_dir):
+        if file.endswith("_all_match_data.csv"):
+            match_data = pd.read_csv("{}/{}".format(file_dir,file))
+            if not match_data.empty:
+                all_matches.append(match_data)
+                pred_data = pd.read_csv("{}/{}_predicted_reference_structures.csv".format(file_dir,file.split("_")[0]))
+                all_uri.append(pred_data[['Document id','Document uri']].drop_duplicates())
+
+    return all_matches, all_uri
+
+def merge_matches(folder_name, org_list, match_refs):
+    """
+    Get all the _all_match_data.csv files for all organisations
+    Concat them all and join to the original references data
+    """
+    all_matches = []
+    all_uri = []
+    for org in org_list:
+        file_dir = "{}/{}".format(folder_name, org)
+        all_matches, all_uri = get_matches(all_matches, all_uri, file_dir)
+
+    all_matches = pd.concat(all_matches, ignore_index=False)
+    all_uri = pd.concat(all_uri, ignore_index=False)
+    
+    all_matches_url = all_matches.join(
+        all_uri.set_index('Document id'),
+        on='Document id'
+        ) # Join with url
+    
+    all_matches_refs = all_matches_url.join(
+        match_refs.set_index('uber_id'),
+        on='WT_Ref_Id'
+        ) # Join with references information
+
+    return all_matches_refs
+
+if __name__ == '__main__':
+
+    # The name you used in your output file name
+    job_name = "charlene" # "pophealth"
+    
+    # The original references data searched for
+    match_refs = pd.read_csv(
+        "/Users/gallaghe/Code/reference-parser/match-references/charlene_publications_format.csv")
+    # "/Users/gallaghe/Code/reference-parser/match-references/MRC_Publications_Nov2018_JGHT_JHSRI_all.csv"
+
+    folder_name = "/Users/gallaghe/Code/reference-parser/tmp/parser-output"
+    who_iris = "{}_who_iris20190207".format(job_name)
+    unicef = "{}_unicef20190131".format(job_name)
+    msf = "{}_msf20190131".format(job_name)
+    nice = "{}_nice20190131".format(job_name)
+
+    all_matches_refs = merge_matches(folder_name, [who_iris, unicef, msf, nice], match_refs)
+
+    all_matches_refs.to_csv('{}/{}_all_matches.csv'.format(folder_name, job_name))

--- a/merge_results.py
+++ b/merge_results.py
@@ -6,41 +6,88 @@ Output is one csv of all the matches from all the organisations you have provide
 
 import fnmatch
 import os
+import glob
+
 import pandas as pd
 
-def get_matches(all_matches, all_uri, file_dir):
-    """
-    Read all the match files from a file directory
-    Append any matches found to all_matches
-    If there is a match then append the uri to all_uri
-    """
-    for file in os.listdir(file_dir):
-        if file.endswith("_all_match_data.csv"):
-            match_data = pd.read_csv("{}/{}".format(file_dir,file))
-            if not match_data.empty:
-                all_matches.append(match_data)
-                pred_data = pd.read_csv("{}/{}_predicted_reference_structures.csv".format(file_dir,file.split("_")[0]))
-                all_uri.append(pred_data[['Document id','Document uri']].drop_duplicates())
 
-    return all_matches, all_uri
-
-def merge_matches(folder_dir, job_name, match_refs):
+def get_csv_names(file_dir, suffix):
     """
-    Get all the _all_match_data.csv files for all organisations
-    Concat them all and join to the original references data
+    This function goes to a folder location and returns a list
+    of all the names of the csvs within it.
+    Input: 
+        file_dir - the file directory to look in
+        suffix - the suffix of the csv name
+    Output: 
+        csv_names - a list of csv folder/filenames
+    """
+    csv_names = glob.glob(
+        os.path.join(file_dir, '**/*{}.csv'.format(suffix)), recursive=True
+    )
+
+    return csv_names
+
+def merge_match_csvs(match_csv_names):
+    """
+    This function merges all the csvs given in match_csv_names
+    Input:
+        match_csv_names -  a list of _all_match_data.csv folder/filenames
+    Output:
+        all_matches - a dataframe containing all the merged match csvs
     """
     all_matches = []
-    all_uri = []
-    for folder_name in fnmatch.filter(os.listdir(folder_dir), '{}_*'.format(job_name)):
-        if os.path.isdir(folder_dir+folder_name):
-            file_dir = folder_dir+folder_name
-            all_matches, all_uri = get_matches(all_matches, all_uri, file_dir)
+    for match_csv_name in match_csv_names:
+        match_data = pd.read_csv(match_csv_name)
+        if not match_data.empty:
+            all_matches.append(match_data)
 
     all_matches = pd.concat(all_matches, ignore_index=False)
-    all_uri = pd.concat(all_uri, ignore_index=False)
+
+    return all_matches
+
+
+def merge_predicted_csvs(predicted_csv_names):
+    """
+    This function gets all the document id & document url from the predicted references csv
+    Input:
+        predicted_csv_names -  a list of _predicted_reference_structures.csv folder/filenames
+    Output:
+        all_url - a dataframe containing document id and document url
+    """
+    all_url = []
+    for predicted_csv_name in predicted_csv_names:
+        # Some (4) of the files don't read in without errors
+        try:
+            pred_data = pd.read_csv(predicted_csv_name)
+        except:
+            print('Read csv issue for file {}'.format(predicted_csv_name))
+        if not pred_data.empty:
+            # Each row has the same doc id and doc url, so only need to use first row
+            all_url.append({'Document id' : pred_data.iloc[0]['Document id'],
+                'Document uri' : pred_data.iloc[0]['Document uri']})
+
+    all_url = pd.DataFrame.from_dict(all_url)
+
+    return all_url
+
+if __name__ == '__main__':
+
+    file_dir = './tmp/parser-output/charlene' # "pophealth", "charlene"
+    output_name = 'merged_all_matches'
     
-    all_matches_url = all_matches.join(
-        all_uri.set_index('Document id'),
+    match_refs = pd.read_csv(
+        "./match-references/charlene_publications_format.csv")
+    # "./match-references/MRC_Publications_Nov2018_JGHT_JHSRI_all.csv"
+    # "./match-references/charlene_publications_format.csv"
+
+    match_csv_names = get_csv_names(file_dir, '_all_match_data')
+    predicted_csv_names = get_csv_names(file_dir, '_predicted_reference_structures')
+
+    all_match = merge_match_csvs(match_csv_names)
+    all_url = merge_predicted_csvs(predicted_csv_names)
+
+    all_matches_url = all_match.join(
+        all_url.set_index('Document id'),
         on='Document id'
         ) # Join with url
     
@@ -49,22 +96,9 @@ def merge_matches(folder_dir, job_name, match_refs):
         on='WT_Ref_Id'
         ) # Join with references information
 
-    return all_matches_refs
+    if not os.path.exists('{}/{}'.format(file_dir, output_name)):
+            os.makedirs('{}/{}'.format(file_dir, output_name))
 
-if __name__ == '__main__':
+    all_matches_refs.to_csv('{}/{}/merged_all_matches.csv'.format(file_dir, output_name))
 
-    # The name you used in your output file name
-    job_name = "charlene" # "pophealth", "charlene"
-    
-    # The original references data searched for
-    match_refs = pd.read_csv(
-        "/Users/gallaghe/Code/reference-parser/match-references/charlene_publications_format.csv")
-    # "/Users/gallaghe/Code/reference-parser/match-references/MRC_Publications_Nov2018_JGHT_JHSRI_all.csv"
-    # "/Users/gallaghe/Code/reference-parser/match-references/charlene_publications_format.csv"
-
-    folder_dir = './tmp/parser-output/'
-
-    all_matches_refs = merge_matches(folder_dir, job_name, match_refs)
-
-    all_matches_refs.to_csv('{}/{}_all_matches.csv'.format(folder_dir, job_name))
 

--- a/merge_results.py
+++ b/merge_results.py
@@ -4,6 +4,7 @@ Manually edit main with the folder names you want to merge all together
 Output is one csv of all the matches from all the organisations you have provided
 """
 
+import fnmatch
 import os
 import pandas as pd
 
@@ -23,16 +24,17 @@ def get_matches(all_matches, all_uri, file_dir):
 
     return all_matches, all_uri
 
-def merge_matches(folder_name, org_list, match_refs):
+def merge_matches(folder_dir, job_name, match_refs):
     """
     Get all the _all_match_data.csv files for all organisations
     Concat them all and join to the original references data
     """
     all_matches = []
     all_uri = []
-    for org in org_list:
-        file_dir = "{}/{}".format(folder_name, org)
-        all_matches, all_uri = get_matches(all_matches, all_uri, file_dir)
+    for folder_name in fnmatch.filter(os.listdir(folder_dir), '{}_*'.format(job_name)):
+        if os.path.isdir(folder_dir+folder_name):
+            file_dir = folder_dir+folder_name
+            all_matches, all_uri = get_matches(all_matches, all_uri, file_dir)
 
     all_matches = pd.concat(all_matches, ignore_index=False)
     all_uri = pd.concat(all_uri, ignore_index=False)
@@ -52,19 +54,17 @@ def merge_matches(folder_name, org_list, match_refs):
 if __name__ == '__main__':
 
     # The name you used in your output file name
-    job_name = "charlene" # "pophealth"
+    job_name = "charlene" # "pophealth", "charlene"
     
     # The original references data searched for
     match_refs = pd.read_csv(
         "/Users/gallaghe/Code/reference-parser/match-references/charlene_publications_format.csv")
     # "/Users/gallaghe/Code/reference-parser/match-references/MRC_Publications_Nov2018_JGHT_JHSRI_all.csv"
+    # "/Users/gallaghe/Code/reference-parser/match-references/charlene_publications_format.csv"
 
-    folder_name = "/Users/gallaghe/Code/reference-parser/tmp/parser-output"
-    who_iris = "{}_who_iris20190207".format(job_name)
-    unicef = "{}_unicef20190131".format(job_name)
-    msf = "{}_msf20190131".format(job_name)
-    nice = "{}_nice20190131".format(job_name)
+    folder_dir = './tmp/parser-output/'
 
-    all_matches_refs = merge_matches(folder_name, [who_iris, unicef, msf, nice], match_refs)
+    all_matches_refs = merge_matches(folder_dir, job_name, match_refs)
 
-    all_matches_refs.to_csv('{}/{}_all_matches.csv'.format(folder_name, job_name))
+    all_matches_refs.to_csv('{}/{}_all_matches.csv'.format(folder_dir, job_name))
+

--- a/parse_latest.py
+++ b/parse_latest.py
@@ -50,15 +50,15 @@ if __name__ == "__main__":
     )
 
     if args.output_url.startswith('file://'):
-        # The directory name will be the name of the organisation 
+        # The output subfolder will be the name of the organisation 
         # and the date of scrape (which is the name of the file)
-        output_url = '{}_{}_{}'.format(
+        output_url = '{}/{}_{}'.format(
             args.output_url,
             org,
             os.path.splitext(os.path.basename(key_name))[0]
         )
         if not os.path.exists(output_url[7:]):
-            os.mkdir(output_url[7:])
+            os.makedirs(output_url[7:])
         
         scraper_file = "s3://{}/{}".format(bucket_name, key_name)
 


### PR DESCRIPTION
# Description

This PR adds a python file to merge all the matched files for each documents and each organisation together into one. It joins the merged outputs with the urls and the references information. Most of the file names etc are user inputted.

I find that some of the _predicted_reference_structures files don't read in without errors (so I add a 'try'). This happens on 4 occasions and the error is:

![screenshot 2019-02-13 at 16 19 00](https://user-images.githubusercontent.com/15956065/52726789-c4d95000-2fab-11e9-9944-0e9d0f555a61.png)


## Type of change
- [ ] :sparkles: New feature

# How Has This Been Tested?

No testing has been done.