### PR TITLE
Fix an error happening sometime in pdf parsing

### DIFF
--- a/wsf-scraper-web/pdf_parser/pdf_parse.py
+++ b/wsf-scraper-web/pdf_parser/pdf_parse.py
@@ -23,6 +23,8 @@ def parse_pdf_document(document):
         'pdftohtml',
         '-i',
         '-xml',
+        '-zoom',
+        '1.5',
         document.name,
         parsed_path
     ]

--- a/wsf-scraper-web/wsf_scraping/settings.py
+++ b/wsf-scraper-web/wsf_scraping/settings.py
@@ -62,7 +62,7 @@ COOKIES_ENABLED = False
 #  who_iris and who_iris_single_page dedicated settings
 WHO_IRIS_RPP = 250
 WHO_IRIS_LIMIT = False
-WHO_IRIS_YEARS = range(2012, datetime.now().year)
+WHO_IRIS_YEARS = range(2012, datetime.now().year + 1)
 
 # nice dedicated settings
 NICE_GET_HISTORY = False

--- a/wsf-scraper-web/wsf_scraping/settings.py
+++ b/wsf-scraper-web/wsf_scraping/settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
+from datetime import datetime
 
 # Get feed configuration from environment variable. Default to debug
 FEED_CONFIG = os.environ.get('SCRAPY_FEED_CONFIG', 'DEBUG')
@@ -61,7 +62,7 @@ COOKIES_ENABLED = False
 #  who_iris and who_iris_single_page dedicated settings
 WHO_IRIS_RPP = 250
 WHO_IRIS_LIMIT = False
-WHO_IRIS_YEARS = [2012, 2013, 2014, 2015, 2016, 2017]
+WHO_IRIS_YEARS = range(2012, datetime.now().year)
 
 # nice dedicated settings
 NICE_GET_HISTORY = False


### PR DESCRIPTION
# Description

The pdf parser module could in some occasion send different results in
the tests. This commit tries to fix it by setting a specific zoom level.

This PR also changes the `WHO_YEARS` settings, as I came accross it and it was outdated.

## Type of change

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Local and unittest (Mac OSx/Python3.6)
