### PR TITLE
Fix #43 for when no reference components are found

### DIFF
--- a/refparse.py
+++ b/refparse.py
@@ -121,6 +121,11 @@ def run_predict(scraper_file, references_file,
         # Split references into components
         splitted_components = process_references(splitted_references)
 
+        # TO DO: Rather than just skip,
+        # return empty lists in predict_references, predict_structure and fuzzy_match_blocks
+        if len(splitted_components)==0:
+            continue
+
         # Predict the references types (eg title/author...)
         # logger.info('[+] Predicting the reference components')
         components_predictions = predict_references(

--- a/refparse.py
+++ b/refparse.py
@@ -123,7 +123,7 @@ def run_predict(scraper_file, references_file,
 
         # TO DO: Rather than just skip,
         # return empty lists in predict_references, predict_structure and fuzzy_match_blocks
-        if not splitted_components:
+        if len(splitted_components) == 0:
             continue
 
         # Predict the references types (eg title/author...)

--- a/refparse.py
+++ b/refparse.py
@@ -123,7 +123,7 @@ def run_predict(scraper_file, references_file,
 
         # TO DO: Rather than just skip,
         # return empty lists in predict_references, predict_structure and fuzzy_match_blocks
-        if len(splitted_components)==0:
+        if not splitted_components:
             continue
 
         # Predict the references types (eg title/author...)


### PR DESCRIPTION
# Description

On very rare occassions there are no reference components found when the references section is cleaned and split, and therefore the code fails because in `predict.py` there is no `predict_all['Predicted Category']` found.

This fixes the issue, but in the future we would like to rather than just skip processing the document, return empty lists in predict_references, predict_structure and fuzzy_match_blocks.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
