### PR TITLE
Refactor fuzzy matching

### DIFF
--- a/refparse.py
+++ b/refparse.py
@@ -103,6 +103,11 @@ def run_predict(scraper_file, references_file,
     mnb = get_file(model_file, 'pickle')
     vectorizer = get_file(vectorizer_file, 'pickle')
 
+    fuzzy_matcher = FuzzyMatcher(
+        ref_file,
+        settings.FUZZYMATCH_THRESHOLD
+    )
+
     t0 = time.time()
     nb_references = 0
     nb_documents = sum(scraper_file['sections'].notnull())
@@ -111,6 +116,9 @@ def run_predict(scraper_file, references_file,
             i,
             nb_documents
         ))
+        # REMOVEEEE
+        if i > 10:
+            break
 
         # Split references section into references
         splitted_references = process_references_section(
@@ -147,12 +155,7 @@ def run_predict(scraper_file, references_file,
             settings.PREDICTION_PROBABILITY_THRESHOLD
         )
 
-        fuzzy_matcher = FuzzyMatcher(
-            ref_file,
-            settings.FUZZYMATCH_THRESHOLD
-        )
-        all_match_data = fuzzy_matcher.fuzzy_match_blocks(
-            settings.BLOCKSIZE,
+        all_match_data = fuzzy_matcher.fuzzy_match(
             predicted_reference_structures,
             settings.FUZZYMATCH_THRESHOLD
         )

--- a/refparse.py
+++ b/refparse.py
@@ -156,8 +156,7 @@ def run_predict(scraper_file, references_file,
         )
 
         all_match_data = fuzzy_matcher.fuzzy_match(
-            predicted_reference_structures,
-            settings.FUZZYMATCH_THRESHOLD
+            predicted_reference_structures
         )
 
         if output_url.startswith('file://'):

--- a/refparse.py
+++ b/refparse.py
@@ -116,9 +116,6 @@ def run_predict(scraper_file, references_file,
             i,
             nb_documents
         ))
-        # REMOVEEEE
-        if i > 10:
-            break
 
         # Split references section into references
         splitted_references = process_references_section(

--- a/settings.py
+++ b/settings.py
@@ -10,7 +10,6 @@ class BaseSettings:
     DEBUG = True
 
     PREDICTION_PROBABILITY_THRESHOLD = 0.75
-    BLOCKSIZE = 1000
     FUZZYMATCH_THRESHOLD = 0.8
 
     ORGANISATION = os.environ.get('ORGANISATION', 'nice')

--- a/tests/test_fuzzy_match.py
+++ b/tests/test_fuzzy_match.py
@@ -1,0 +1,105 @@
+import unittest
+
+from pandas.util.testing import assert_frame_equal
+import pandas as pd
+
+from utils import FuzzyMatcher
+from settings import settings
+
+
+class TestFuzzyMatcherInit(unittest.TestCase):
+	def test_empty_title(self):
+		real_publications = pd.DataFrame({
+			'title': []
+		})
+		threshold = 75
+		with self.assertRaises(ValueError):
+			FuzzyMatcher(real_publications, threshold)
+
+	def test_no_title(self):
+		real_publications = pd.DataFrame({})
+		threshold = 75
+		with self.assertRaises(KeyError):
+			FuzzyMatcher(real_publications, threshold)
+
+	def test_no_string_titles(self):
+		real_publications = pd.DataFrame({
+			'title': [1,2]
+		})
+		threshold = 75
+		with self.assertRaises(AttributeError):
+			FuzzyMatcher(real_publications, threshold)
+
+	def test_init_variables(self):
+		real_publications = pd.DataFrame({
+			'title': ['Malaria', 'Zika']
+		})
+		threshold = 0
+		fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
+		assert_frame_equal(
+			fuzzy_matcher.real_publications, real_publications
+		)
+		self.assertEqual(
+			fuzzy_matcher.threshold, threshold
+		)
+		self.assertTrue(
+			fuzzy_matcher.tfidf_matrix.size != 0
+		)
+
+class TestFuzzyMatch(unittest.TestCase):
+	def init_fuzzy_matcher(self):
+		real_publications = pd.DataFrame({
+			'title': ['Malaria', 'Zika'],
+			'uber_id': [1, 2]
+		})
+		threshold = settings.FUZZYMATCH_THRESHOLD
+		fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
+		return fuzzy_matcher
+
+	def test_empty_predicted_publications(self):
+		fuzzy_matcher = self.init_fuzzy_matcher()
+		predicted_publications = pd.DataFrame({
+			'Document id': [],
+            'Reference id': [],
+            'Title': []			
+		})
+		self.assertTrue(
+			fuzzy_matcher.fuzzy_match(predicted_publications).size == 0
+		) 
+
+	def test_no_match(self):
+		fuzzy_matcher = self.init_fuzzy_matcher()
+		predicted_publications = pd.DataFrame({
+			'Document id': [1],
+            'Reference id': [1],
+            'Title': ['Ebola']			
+		})
+		self.assertTrue(
+			fuzzy_matcher.fuzzy_match(predicted_publications).size == 0
+		) 
+
+	def test_one_match(self):
+		fuzzy_matcher = self.init_fuzzy_matcher()
+		predicted_publications = pd.DataFrame({
+			'Document id': [10],
+            'Reference id': [11],
+            'Title': ['Malaria']			
+		})
+		match_data = fuzzy_matcher.fuzzy_match(predicted_publications)
+		self.assertEqual(match_data.shape[0], 1)
+		self.assertEqual(match_data.iloc[0]['Document id'], 10)
+
+	def test_close_match(self):
+		real_publications = pd.DataFrame({
+			'title': ['Malaria is caused by mosquitoes'],
+			'uber_id': [1]
+		})
+		threshold = settings.FUZZYMATCH_THRESHOLD
+		fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
+		predicted_publications = pd.DataFrame({
+			'Document id': [10],
+            'Reference id': [11],
+            'Title': ['Malaria']			
+		})
+		match_data = fuzzy_matcher.fuzzy_match(predicted_publications)
+		self.assertEqual(match_data.shape[0], 0) 

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -6,15 +6,16 @@ from sklearn.metrics.pairwise import cosine_similarity
 
 
 class FuzzyMatcher:
-    def __init__(self, real_publications, titles):
+    def __init__(self, real_publications, match_threshold):
         self.logger = settings.logger
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
         self.tfidf_matrix = self.vectorizer.fit_transform(
             real_publications['title']
         )
         self.real_publications = real_publications
+        self.threshold = match_threshold
 
-    def match_vectorised(self, predicted_publications, threshold):
+    def match_vectorised(self, predicted_publications):
         # Todo - Make sure not resetting index works the same
         predicted_publications.dropna(
             subset=['Title'],
@@ -29,7 +30,7 @@ class FuzzyMatcher:
         )
 
         high_similarity_indices = np.argwhere(
-            title_similarities > threshold
+            title_similarities > self.threshold
         )
         
         predicted_index = high_similarity_indices[:,0]
@@ -50,7 +51,7 @@ class FuzzyMatcher:
         
         return match_data
 
-    def fuzzy_match(self, predicted_publications, threshold):
+    def fuzzy_match(self, predicted_publications):
         self.logger.info(
             "Fuzzy matching for %s predicted publications ...",
             len(predicted_publications)
@@ -58,8 +59,7 @@ class FuzzyMatcher:
 
         all_match_data = pd.DataFrame(
             self.match_vectorised(
-                predicted_publications,
-                threshold
+                predicted_publications
             ),
             columns=[
                 'Document id',

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -16,6 +16,17 @@ class FuzzyMatcher:
         self.threshold = match_threshold
 
     def match_vectorised(self, predicted_publications):
+
+        if predicted_publications.shape[0] == 0:
+            return pd.DataFrame({
+                'Document id': [],
+                'Reference id': [],
+                'Title': [],
+                'title': [],
+                'uber_id': [],
+                'Cosine_Similarity': []
+            })
+
         # Todo - Make sure not resetting index works the same
         predicted_publications.dropna(
             subset=['Title'],


### PR DESCRIPTION
This PR aims to improve the readability of fuzzy matching and add tests. To achieve this we do the following
* remove batching predictions into blocks since now we process references document by document and this is not needed.
* better utilise pandas and numpy features to remove part of the code where intermediate list or tuples where introduced
* rename variables to make their function clearer, for example high_similarity_index to above_threshold_indices and use of plural indices instead of index
* taking care of empty dataframe as input which now returns an empty dataframe back

The use of pandas was not removed as its use here is satisfied. We need to perform matrix operations and return subset of matrices which is more efficient with the data structure underpining pandas. What we can do in the future though is accept a non dataframe structure and return a non dataframe structure while internally we still utilise dataframes for the matrix operations.