### PR TITLE
Add a "make tests" command to the Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,10 @@ codebuild-docker-push: push
 virtualenv: $(VIRTUALENV)/.installed
 
 .PHONY: tests
+tests: virtualenv
 tests:
-	python -m unittest
+	./build/virtualenv/bin/python -m unittest
+
 
 .PHONY: all
 all: image

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,17 @@ $(VIRTUALENV)/.installed: requirements.txt
 # Builds, tests, & pushes docker images with CodeBuild specific VERSION
 # and LATEST_TAG.
 .PHONY: codebuild-docker-push
+codebuild-docker-push: tests
 codebuild-docker-push: VERSION := $(CODEBUILD_VERSION)
 codebuild-docker-push: LATEST_TAG := $(CODEBUILD_LATEST_TAG)
 codebuild-docker-push: push
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV)/.installed
+
+.PHONY: tests
+tests:
+	python -m unittest
 
 .PHONY: all
 all: image

--- a/model_tests/tests_utils.py
+++ b/model_tests/tests_utils.py
@@ -5,8 +5,8 @@ from .test_settings import settings
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-from utils import (Predictor, FuzzyMatcher,
-                   split_sections, split_reference)
+from utils import (predict_references, predict_structure, FuzzyMatcher,
+                   split_section, process_references_section)
 
 
 def test_get_reference_components(predicted_number_refs, actual_number_refs):
@@ -233,8 +233,8 @@ def test_number_refs(raw_text_data, actual_number_refs, organisation_regex,
                     references_section = this_doc_reference[
                         "sections"
                     ]["Reference"]
-                    references = split_sections(references_section,
-                                                organisation_regex)
+                    references = split_section(references_section,
+                                               organisation_regex)
 
                     if this_document_actual_number == 0:
                         difference_per = None
@@ -289,7 +289,9 @@ def test_structure(actual_reference_structures, components_id_name,
     raw_reference_components = []
     for _, actual_structure in actual_reference_structures.iterrows():
         # Get the components for this reference and store
-        components = split_reference(actual_structure['Actual reference'])
+        components = process_references_section(
+            actual_structure['Actual reference']
+        )
         for component in components:
             raw_reference_components.append({
                 'Reference component': component,
@@ -301,12 +303,10 @@ def test_structure(actual_reference_structures, components_id_name,
     reference_components_ref_structures = pd.DataFrame(
         raw_reference_components)
 
-    predictor = Predictor()
-
-    ref_components_ref_structures_predictions = predictor.predict_references(
+    ref_components_ref_structures_predictions = predict_references(
         mnb, vectorizer, reference_components_ref_structures)
 
-    predicted_reference_structures = predictor.predict_structure(
+    predicted_reference_structures = predict_structure(
         ref_components_ref_structures_predictions,
         settings.PREDICTION_PROBABILITY_THRESHOLD)
 

--- a/tests/test_separate.py
+++ b/tests/test_separate.py
@@ -1,34 +1,45 @@
 import unittest
 
-from utils import split_sections, process_reference_section
-from main import SectionedDocument
+from utils import split_section, process_references_section
+from refparse import SectionedDocument
+
 
 class TestSplit(unittest.TestCase):
-	
-	def test_empty_sections(self):
-		references = split_sections("")
-		self.assertEqual(references, [], "Should be []")
 
-	def test_oneline_section(self):
-		references = split_sections("This is one line")
-		self.assertEqual(references, ["This is one line"], "Should be ['This is one line']")
+    def test_empty_sections(self):
+        references = split_section("")
+        self.assertEqual(references, [], "Should be []")
 
-	def test_empty_lines_section(self):
-		references = split_sections("\n\n\n")
-		self.assertEqual(references, [], "Should be []")
+    def test_oneline_section(self):
+        references = split_section("This is one line")
+        self.assertEqual(
+            references,
+            ["This is one line"],
+            "Should be ['This is one line']"
+        )
 
-	def test_normal_section(self):
-		references = split_sections("One reference\nTwo references\nThree references\n")
-		self.assertEqual(references, ["One reference", "Two references", "Three references"],
-			"Should be ['One reference', 'Two reference', 'Three reference']")
+    def test_empty_lines_section(self):
+        references = split_section("\n\n\n")
+        self.assertEqual(references, [], "Should be []")
+
+    def test_normal_section(self):
+        references = split_section(
+            "One reference\nTwo references\nThree references\n"
+        )
+        self.assertEqual(
+            references,
+            ["One reference", "Two references", "Three references"],
+            "Should be ['One reference', 'Two reference', 'Three reference']"
+        )
+
 
 class TestProcessReferenceSection(unittest.TestCase):
 
-	def test_no_section_in_document(self):
-		doc = SectionedDocument(
-			None,
-			'uri',
-			'id'
-		)
-		with self.assertRaises(TypeError):
-			process_reference_section(doc, '\n')
+    def test_no_section_in_document(self):
+        doc = SectionedDocument(
+            None,
+            'uri',
+            'id'
+        )
+        with self.assertRaises(AssertionError):
+            process_references_section(doc, '\n')

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-from .split import process_references_section
+from .split import process_references_section, split_section
 from .predict import predict_references, predict_structure, process_references
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
@@ -12,5 +12,6 @@ __all__ = [
     serialise_matched_reference,
     serialise_reference,
     predict_references,
-    predict_structure
+    predict_structure,
+    split_section,
 ]

--- a/wsf-scraper-web/Makefile
+++ b/wsf-scraper-web/Makefile
@@ -52,8 +52,9 @@ $(VIRTUALENV)/.installed: requirements.txt
 virtualenv: $(VIRTUALENV)/.installed
 
 .PHONY: tests
+tests: virtualenv
 tests:
-	python -m unittest
+	./build/virtualenv/bin/python -m unittest
 
 .PHONY: all
 all: base_image image

--- a/wsf-scraper-web/Makefile
+++ b/wsf-scraper-web/Makefile
@@ -38,6 +38,7 @@ push: image
 .PHONY: codebuild-docker-push
 codebuild-docker-push: VERSION := $(CODEBUILD_VERSION)
 codebuild-docker-push: LATEST_TAG := $(CODEBUILD_LATEST_TAG)
+codebuild-docker-push: tests
 codebuild-docker-push: push
 
 $(VIRTUALENV)/.installed: requirements.txt
@@ -49,6 +50,10 @@ $(VIRTUALENV)/.installed: requirements.txt
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV)/.installed
+
+.PHONY: tests
+tests:
+	python -m unittest
 
 .PHONY: all
 all: base_image image

--- a/wsf-scraper-web/tests/test_db_tools.py
+++ b/wsf-scraper-web/tests/test_db_tools.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import logging
 from tools import DatabaseConnector
 
 
@@ -7,9 +8,17 @@ class TestDBTools(unittest.TestCase):
 
     def setUp(self):
         """Assuming the database is already set up."""
-        self.database = DatabaseConnector(
-            os.environ['DATABASE_URL_TEST']
-        )
+        database_url = os.getenv('DATABASE_URL_TEST')
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
+
+        if not database_url:
+            self.logger.warning('No DATABASE_URL_TEST in environment.'
+                                'Unable to unittest the database methods.')
+            self.database = None
+            return
+
+        self.database = DatabaseConnector(database_url)
         mock_publication = {
             'title': 'foo',
             'uri': 'http://foo.bar',
@@ -38,34 +47,37 @@ class TestDBTools(unittest.TestCase):
         self.database.insert_joints_and_text('keyword', keywords, id_pub)
 
     def tearDown(self):
-        self.database._execute('DELETE FROM publications_types')
-        self.database._execute('DELETE FROM publications_subjects')
-        self.database._execute('DELETE FROM publications_sections')
-        self.database._execute('DELETE FROM publications_keywords')
-        self.database._execute('DELETE FROM type')
-        self.database._execute('DELETE FROM subject')
-        self.database._execute('DELETE FROM section')
-        self.database._execute('DELETE FROM keyword')
-        self.database._execute('DELETE FROM publication')
-        self.database._execute('DELETE FROM provider')
+        if self.database:
+            self.database._execute('DELETE FROM publications_types')
+            self.database._execute('DELETE FROM publications_subjects')
+            self.database._execute('DELETE FROM publications_sections')
+            self.database._execute('DELETE FROM publications_keywords')
+            self.database._execute('DELETE FROM type')
+            self.database._execute('DELETE FROM subject')
+            self.database._execute('DELETE FROM section')
+            self.database._execute('DELETE FROM keyword')
+            self.database._execute('DELETE FROM publication')
+            self.database._execute('DELETE FROM provider')
 
     def test_full_publication(self):
-        self.assertTrue(self.database.get_scraping_info('0' * 32))
+        if self.database:
+            self.assertTrue(self.database.get_scraping_info('0' * 32))
 
     def test_joints(self):
-        self.database._execute('SELECT * FROM section')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM keyword')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM publications_sections')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM publications_keywords')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM type')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM publications_types')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM subject')
-        self.assertTrue(self.database.cursor.fetchone())
-        self.database._execute('SELECT * FROM publications_subjects')
-        self.assertTrue(self.database.cursor.fetchone())
+        if self.database:
+            self.database._execute('SELECT * FROM section')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM keyword')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM publications_sections')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM publications_keywords')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM type')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM publications_types')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM subject')
+            self.assertTrue(self.database.cursor.fetchone())
+            self.database._execute('SELECT * FROM publications_subjects')
+            self.assertTrue(self.database.cursor.fetchone())


### PR DESCRIPTION
# Description

We want to run our unittests in codepipeline before pushing the image. In order to do so, we need to add a `tests` recipe to the Makefile, and to run it prior to the `codepipeline-docker-push: push` step. 

This PR also fixes a few codestyle issues and renaming related issues.

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature

# How Has This Been Tested?

N/A

# To do

Find a way to run tests on the database
