### PR TITLE
Reset indexes in fuzzy match

### DIFF
--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -52,13 +52,13 @@ class FuzzyMatcher:
             predicted_publications.iloc[predicted_indices][[
                 'Document id',
                 'Reference id',
-                'Title']],
+                'Title']].reset_index(),
             self.real_publications.iloc[real_indices][[
                 'title',
-                'uber_id']],
+                'uber_id']].reset_index(),
             pd.DataFrame({
                 'Cosine_Similarity': cosine_similarities
-            })],
+            }).reset_index()],
             axis=1)
 
         return match_data


### PR DESCRIPTION
# Description

Without reseting the index when the 3 dataframes are concatenated they are done by index rather than order, causing an incorrect output.
e.g.

![screenshot 2019-02-19 at 15 40 30](https://user-images.githubusercontent.com/15956065/53028744-5c80e780-345f-11e9-9500-4f3db8391ce0.png)

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

Previous error it caused no longer happens:

![screenshot 2019-02-19 at 15 16 32](https://user-images.githubusercontent.com/15956065/53028804-79b5b600-345f-11e9-98f5-118873ceda63.png)