### PR TITLE
Fix examples by adding a correct path to publications so they run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mkdir -p ./tmp/parser-output/output_folder_name
 
 python ./refparse.py \
     --scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
-    --references-file "path/to/references.csv" \
+    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
     --output-url "file://./tmp/parser-output/output_folder_name"
 ```
@@ -85,7 +85,7 @@ If you want to specify the arguments for the other inputs then you can, otherwis
 
 ```
 python ./parse_latest.py msf \
-    --references-file "path/to/references.csv" \
+    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
     --output-url "file://./tmp/parser-output/output_folder_name"
 ```
@@ -96,8 +96,8 @@ Warning that this could take some time.
 The parsed and matched references from each documents are saved in a separate file in the output folder. You can merge all of them together by running
 ```
 python merge_results.py \
-    --references-file "s3://datalabs-data/reference_parser/data/raw/uber_api_publications.csv" \
-    --output-url  "file://./tmp/parser-output/output_folder_name"
+    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
+    --output-url  "./tmp/parser-output/output_folder_name"
 ```
 
 ## Unit testing


### PR DESCRIPTION
This PR aims to make the examples in the readme run. To do so I add an s3 url that is valid for Wellcome publications and fix the path of merge results which does not use the `file://` prefix.

This is a temporary solution until we add some sample data into the repo so that a user that does not work at wellcome can run the code