### PR TITLE
requirements.txt: address CVE-2018-16516

### DIFF
--- a/policytool/Makefile
+++ b/policytool/Makefile
@@ -44,7 +44,7 @@ $(VIRTUALENV)/.installed: requirements.txt
 	@if [ -d $(VIRTUALENV) ]; then rm -rf $(VIRTUALENV); fi
 	@mkdir -p $(VIRTUALENV)
 	virtualenv --python python3 $(VIRTUALENV)
-	$(VIRTUALENV)/bin/pip3 install -r requirements.txt
+	AIRFLOW_GPL_UNIDECODE=yes $(VIRTUALENV)/bin/pip3 install -r requirements.txt
 	touch $@
 
 .PHONY: virtualenv

--- a/policytool/requirements.txt
+++ b/policytool/requirements.txt
@@ -3,7 +3,7 @@ alembic<0.9,>=0.8.3
 bleach~=2.1.3
 configparser<3.6.0,>=3.5.0
 flask<0.13,>=0.12.4
-flask-admin==1.5.2
+flask-admin==1.5.3
 Babel==2.6.0
 Click==7.0
 flask-appbuilder==1.12.1


### PR DESCRIPTION
# Description

This resolves #94 :

* Address CVE-2018-16516 by upgrading flask-admin to 1.5.3.
* Update Makefile so `make virtualenv` works again, now that airflow
  is a dependency.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
make docker-test
```

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`

N/A:
- [ ] I included tests in my PR
- [ ] Any dependent changes have been merged and published in downstream modules
