### PR TITLE
Refactor predict structure

### DIFF
--- a/refparse.py
+++ b/refparse.py
@@ -108,10 +108,12 @@ def run_predict(scraper_file, references_file,
         settings.FUZZYMATCH_THRESHOLD
     )
 
+    sectioned_documents = transform_scraper_file(scraper_file)
+
     t0 = time.time()
     nb_references = 0
-    nb_documents = sum(scraper_file['sections'].notnull())
-    for i, doc in enumerate(transform_scraper_file(scraper_file)):
+    nb_documents = len(sectioned_documents)
+    for i, doc in enumerate(sectioned_documents):
         logger.info('[+] Processing references from document {} of {}'.format(
             i,
             nb_documents

--- a/refparse.py
+++ b/refparse.py
@@ -309,4 +309,5 @@ if __name__ == '__main__':
 
     except Exception as e:
         sentry_sdk.capture_exception(e)
+        logger.error(e)
         raise

--- a/refparse.py
+++ b/refparse.py
@@ -13,7 +13,7 @@ import sentry_sdk
 
 from utils import (FileManager,
                    FuzzyMatcher,
-                   split_references_section,
+                   split_section,
                    structure_references)
 from models import DatabaseEngine
 from settings import settings
@@ -116,16 +116,23 @@ def run_predict(scraper_file, references_file,
             nb_documents
         ))
 
-        splitted_references = split_references_section(
+        splitted_references = split_section(
             doc.section,
             settings.ORGANISATION_REGEX
         )
 
+        # A better name would be parse here but we use it differently here
         structured_references = structure_references(
             pool_map,
             model,
             splitted_references
         )
+
+        # DataFrame is pushed here because
+        # - fuzzy matcher needs a dataframe
+        # - to_csv needs a dataframe
+        # so instead of init the dataframe twice we do it here for now
+        structured_references = pd.DataFrame(structured_references)
         structured_references['Document id'] = doc.id
         structured_references['Document uri'] = doc.uri
 

--- a/refparse.py
+++ b/refparse.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser
 from collections import namedtuple
 from multiprocessing import Pool
 from urllib.parse import urlparse
+from functools import partial
 import os
 import time
 
@@ -139,15 +140,14 @@ def run_predict(scraper_file, references_file,
             settings.ORGANISATION_REGEX
         )
 
-        # To do: Replace for loop with pool map to regain efficiency
-        structured_references = []
-        for reference in splitted_references:
-            # A better name would be parse here but we use it differently here
-            structured_reference = structure_reference(
-                model,
-                reference
-            )
-            structured_references.append(structured_reference)
+        # For some weird reason not using pool map 
+        #   in my laptop is more performant
+        structured_references = pool_map(
+            # A better name would be parse_reference
+            #   here but we use it differently here
+            partial(structure_reference, model),
+            splitted_references
+        )
 
         structured_references = transform_structured_references(
             splitted_references,

--- a/refparse.py
+++ b/refparse.py
@@ -10,6 +10,7 @@ import os
 import time
 
 import sentry_sdk
+import pandas as pd
 
 from utils import (FileManager,
                    FuzzyMatcher,

--- a/refparse.py
+++ b/refparse.py
@@ -117,7 +117,7 @@ def run_predict(scraper_file, references_file,
         ))
 
         splitted_references = split_references_section(
-            doc,
+            doc.section,
             settings.ORGANISATION_REGEX
         )
 
@@ -126,6 +126,8 @@ def run_predict(scraper_file, references_file,
             model,
             splitted_references
         )
+        structured_references['Document id'] = doc.id
+        structured_references['Document uri'] = doc.uri
 
         matched_references = fuzzy_matcher.fuzzy_match(
             structured_references

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,7 +2,7 @@ import os.path
 import unittest
 import pickle
 
-from utils import predict_references
+from utils import predict_components
 
 MODELS_DIR = os.path.join(os.path.dirname(__file__), '..', 'reference_parser_models')
 
@@ -11,11 +11,11 @@ with open(os.path.join(MODELS_DIR, "reference_parser_pipeline.pkl"), "rb") as f:
 
 class TestPredict(unittest.TestCase):
 	def test_empty_components(self):
-		components_predictions = predict_references(map,model,[])
+		components_predictions = predict_components(map,model,[])
 		self.assertEqual(components_predictions, [], "Should be []")
 
 	def test_normal_components(self):
-		components_predictions = predict_references(map,model,["Component","Component","Component"])
+		components_predictions = predict_components(map,model,["Component","Component","Component"])
 		all_categories = ['Authors', 'Title', 'Journal', 'PubYear', 'Volume', 'Issue', 'Pagination']
 		self.assertEqual(
 			isinstance(components_predictions, list),
@@ -27,15 +27,15 @@ class TestPredict(unittest.TestCase):
 			)
 
 	def test_size(self):
-		components_predictions = predict_references(map,model,["Component","Component","Component"])
+		components_predictions = predict_components(map,model,["Component","Component","Component"])
 		self.assertEqual(len(components_predictions) , 3, "Should be 3")
 
 	def test_string_component(self):
-		components_predictions = predict_references(map,model,["Component"])
+		components_predictions = predict_components(map,model,["Component"])
 		self.assertEqual(isinstance(components_predictions[0]['Predicted Category'], str), True, "Should be a string")
 
 	def test_year_component(self):
-		components_predictions = predict_references(map,model,["1999"])
+		components_predictions = predict_components(map,model,["1999"])
 		self.assertEqual(components_predictions[0]['Predicted Category'], 'PubYear', "Should be 'PubYear'")
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -11,11 +11,11 @@ with open(os.path.join(MODELS_DIR, "reference_parser_pipeline.pkl"), "rb") as f:
 
 class TestPredict(unittest.TestCase):
 	def test_empty_components(self):
-		components_predictions = predict_components(map,model,[])
+		components_predictions = predict_components(model,[])
 		self.assertEqual(components_predictions, [], "Should be []")
 
 	def test_normal_components(self):
-		components_predictions = predict_components(map,model,["Component","Component","Component"])
+		components_predictions = predict_components(model,["Component","Component","Component"])
 		all_categories = ['Authors', 'Title', 'Journal', 'PubYear', 'Volume', 'Issue', 'Pagination']
 		self.assertEqual(
 			isinstance(components_predictions, list),
@@ -27,15 +27,15 @@ class TestPredict(unittest.TestCase):
 			)
 
 	def test_size(self):
-		components_predictions = predict_components(map,model,["Component","Component","Component"])
+		components_predictions = predict_components(model,["Component","Component","Component"])
 		self.assertEqual(len(components_predictions) , 3, "Should be 3")
 
 	def test_string_component(self):
-		components_predictions = predict_components(map,model,["Component"])
+		components_predictions = predict_components(model,["Component"])
 		self.assertEqual(isinstance(components_predictions[0]['Predicted Category'], str), True, "Should be a string")
 
 	def test_year_component(self):
-		components_predictions = predict_components(map,model,["1999"])
+		components_predictions = predict_components(model,["1999"])
 		self.assertEqual(components_predictions[0]['Predicted Category'], 'PubYear', "Should be 'PubYear'")
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,12 +2,13 @@ import os.path
 import unittest
 import pickle
 
-from utils import predict_components
+from utils import predict_components, merge_components, split_reference
 
 MODELS_DIR = os.path.join(os.path.dirname(__file__), '..', 'reference_parser_models')
 
 with open(os.path.join(MODELS_DIR, "reference_parser_pipeline.pkl"), "rb") as f:
     model = pickle.load(f)
+
 
 class TestPredict(unittest.TestCase):
 	def test_empty_components(self):
@@ -39,3 +40,119 @@ class TestPredict(unittest.TestCase):
 		self.assertEqual(components_predictions[0]['Predicted Category'], 'PubYear', "Should be 'PubYear'")
 
 
+class TestSplit(unittest.TestCase):
+	def test_no_reference(self):
+		self.assertEqual(split_reference(None), [], "Should be []")
+
+	def test_empty_reference(self):
+		self.assertEqual(split_reference(""), [], "Should be []")
+
+	def test_no_element_to_split(self):
+		self.assertEqual(
+			split_reference("This is a reference"),
+			["This is a reference"],
+			"Should be a list with one element"
+		)
+
+	def test_split_by_comma(self):
+		self.assertEqual(
+			split_reference("This, is a reference"),
+			["This", "is a reference"],
+			"Should be a list with two elements"
+		)
+
+	def test_split_by_question_mark(self):
+		self.assertEqual(
+			split_reference("To be? Or not to be?"),
+			["To be?", "Or not to be?"],
+			"Should be a list with two elements"
+		)
+
+	def test_split_by_exclamation_mark(self):
+		self.assertEqual(
+			split_reference("To be! What a silly question"),
+			["To be!", "What a silly question"],
+			"Should be a list with two elements"
+		)
+
+
+class TestMerge(unittest.TestCase):
+	def test_empty_components(self):
+		self.assertEqual(merge_components([]), [], "Should be []")
+
+	def test_incorrect_classes_passed(self):
+		components = [
+			{'Predicted Category': 'Junk'},
+			{'Predicted Category': 'Apple'},
+			{'Predicted Category': 'Google'}
+		]
+		empty_structured_components = {
+			'Authors': '',
+			'Volume': '',
+			'Journal': '',
+			'Title': '',
+			'Pagination': '',
+			'Issue': '',
+			'PubYear': ''
+		}
+		self.assertEqual(
+			merge_components(components),
+			empty_structured_components,
+			"Should be {}".format(empty_structured_components)
+		)
+
+	def test_all_classes_returned(self):
+		components = [
+			{
+				'Predicted Category': 'Title',
+				'Prediction Probability': 1,
+				'Reference component': 'This is a title.'
+			},
+		]
+		expected_structured_components = {
+			'Authors': '',
+			'Volume': '',
+			'Journal': '',
+			'Title': 'This is a title.',
+			'Pagination': '',
+			'Issue': '',
+			'PubYear': ''
+		}
+		self.assertEqual(
+			merge_components(components),
+			expected_structured_components,
+			"Should be {}".format(expected_structured_components)
+		)
+
+	def test_merge_works(self):
+		components = [
+			{
+				'Predicted Category': 'Title',
+				'Prediction Probability': 1,
+				'Reference component': 'This'
+			},
+			{
+				'Predicted Category': 'Title',
+				'Prediction Probability': 1,
+				'Reference component': 'is a title.'
+			},
+			{
+				'Predicted Category': 'Authors',
+				'Prediction Probability': 1,
+				'Reference component': 'Nick'
+			},
+		]
+		expected_structured_components = {
+			'Authors': 'Nick',
+			'Volume': '',
+			'Journal': '',
+			'Title': 'This, is a title.',
+			'Pagination': '',
+			'Issue': '',
+			'PubYear': ''
+		}
+		self.assertEqual(
+			merge_components(components),
+			expected_structured_components,
+			"Should be {}".format(expected_structured_components)
+		)

--- a/tests/test_separate.py
+++ b/tests/test_separate.py
@@ -1,6 +1,6 @@
 import unittest
 
-from utils import split_section, process_references_section
+from utils import split_section, split_references_section
 from refparse import SectionedDocument
 
 
@@ -42,4 +42,4 @@ class TestProcessReferenceSection(unittest.TestCase):
             'id'
         )
         with self.assertRaises(AssertionError):
-            process_references_section(doc, '\n')
+            split_references_section(doc, '\n')

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,17 +1,17 @@
 import unittest
 
-from utils import _split_section, split_section
+from utils import split_section
 from refparse import SectionedDocument
 
 
 class TestSplit(unittest.TestCase):
 
     def test_empty_sections(self):
-        references = _split_section("")
+        references = split_section("")
         self.assertEqual(references, [], "Should be []")
 
     def test_oneline_section(self):
-        references = _split_section("This is one line")
+        references = split_section("This is one line")
         self.assertEqual(
             references,
             ["This is one line"],
@@ -19,11 +19,11 @@ class TestSplit(unittest.TestCase):
         )
 
     def test_empty_lines_section(self):
-        references = _split_section("\n\n\n")
+        references = split_section("\n\n\n")
         self.assertEqual(references, [], "Should be []")
 
     def test_normal_section(self):
-        references = _split_section(
+        references = split_section(
             "One reference\nTwo references\nThree references\n"
         )
         self.assertEqual(
@@ -31,10 +31,3 @@ class TestSplit(unittest.TestCase):
             ["One reference", "Two references", "Three references"],
             "Should be ['One reference', 'Two reference', 'Three reference']"
         )
-
-
-class TestProcessReferenceSection(unittest.TestCase):
-
-    def test_no_section_in_document(self):
-        with self.assertRaises(AssertionError):
-            split_section(None, '\n')

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,17 +1,17 @@
 import unittest
 
-from utils import split_section, split_references_section
+from utils import _split_section, split_section
 from refparse import SectionedDocument
 
 
 class TestSplit(unittest.TestCase):
 
     def test_empty_sections(self):
-        references = split_section("")
+        references = _split_section("")
         self.assertEqual(references, [], "Should be []")
 
     def test_oneline_section(self):
-        references = split_section("This is one line")
+        references = _split_section("This is one line")
         self.assertEqual(
             references,
             ["This is one line"],
@@ -19,11 +19,11 @@ class TestSplit(unittest.TestCase):
         )
 
     def test_empty_lines_section(self):
-        references = split_section("\n\n\n")
+        references = _split_section("\n\n\n")
         self.assertEqual(references, [], "Should be []")
 
     def test_normal_section(self):
-        references = split_section(
+        references = _split_section(
             "One reference\nTwo references\nThree references\n"
         )
         self.assertEqual(
@@ -36,10 +36,5 @@ class TestSplit(unittest.TestCase):
 class TestProcessReferenceSection(unittest.TestCase):
 
     def test_no_section_in_document(self):
-        doc = SectionedDocument(
-            None,
-            'uri',
-            'id'
-        )
         with self.assertRaises(AssertionError):
-            split_references_section(doc, '\n')
+            split_section(None, '\n')

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,16 +1,15 @@
-from .split import split_section, _split_section
-from .parse import predict_components, merge_components, split_references, structure_references
+from .split import split_section
+from .parse import predict_components, merge_components, split_reference, structure_reference
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
 
 __all__ = [
-    _split_section,
     split_section,
-    split_references,
+    split_reference,
     predict_components,
     merge_components,
-    structure_references,
+    structure_reference,
     FuzzyMatcher,
     FileManager,
     serialise_matched_reference,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,11 +1,11 @@
-from .split import process_references_section, split_section
-from .predict import predict_references, predict_structure, process_references
+from .split import split_references_section, split_section
+from .predict import predict_references, predict_structure, process_references, structure_references
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
 
 __all__ = [
-    process_references_section,
+    split_references_section,
     process_references,
     FuzzyMatcher,
     FileManager,
@@ -13,5 +13,6 @@ __all__ = [
     serialise_reference,
     predict_references,
     predict_structure,
+    structure_references,
     split_section,
 ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,18 +1,18 @@
-from .split import split_references_section, split_section
-from .predict import predict_references, predict_structure, process_references, structure_references
+from .split import split_section, _split_section
+from .parse import predict_components, merge_components, split_references, structure_references
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
 
 __all__ = [
-    split_references_section,
-    process_references,
+    _split_section,
+    split_section,
+    split_references,
+    predict_components,
+    merge_components,
+    structure_references,
     FuzzyMatcher,
     FileManager,
     serialise_matched_reference,
-    serialise_reference,
-    predict_references,
-    predict_structure,
-    structure_references,
-    split_section,
+    serialise_reference
 ]

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -16,7 +16,6 @@ class FuzzyMatcher:
         self.threshold = match_threshold
 
     def match_vectorised(self, predicted_publications):
-
         if predicted_publications.shape[0] == 0:
             return pd.DataFrame({
                 'Document id': [],

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -63,10 +63,10 @@ class FuzzyMatcher:
         return match_data
 
     def fuzzy_match(self, predicted_publications):
-        self.logger.info(
-            "Fuzzy matching for %s predicted publications ...",
-            len(predicted_publications)
-        )
+        # self.logger.info(
+        #     "Fuzzy matching for %s predicted publications ...",
+        #     len(predicted_publications)
+        # )
 
         all_match_data = self.match_vectorised(
             predicted_publications
@@ -79,5 +79,6 @@ class FuzzyMatcher:
             inplace=True
         )
 
-        self.logger.info(all_match_data.head())
+        if not all_match_data.empty:
+            self.logger.info(all_match_data.head())
         return all_match_data

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -30,29 +30,15 @@ def split_reference(reference):
     return components
 
 
-def split_references(references):
-    raw_reference_components = []
-    for reference in references:
-        # Get the components for this reference and store
-        components = split_reference(reference['Reference'])
-
-        for component in components:
-            raw_reference_components.append({
-                'Reference component': component,
-                'Reference id': reference['Reference id']
-            })
-
-    # logger.info("Reference components found")
-    return raw_reference_components
-
-
-def decide_components(reference_components):
+def merge_components(reference_components):
     """With the predicted components of one reference, decide which of
     these should be used for each component i.e. if there are multiple
     authors predicted and they arent next to each other, then decide which
     one to use.
     """
-    
+    if not reference_components:
+        return []
+
     # Add a group number for components that are next to components
     #   with same category. For example title next to a title.
     group_index = 1
@@ -90,53 +76,6 @@ def decide_components(reference_components):
     return structured_reference
 
 
-def merge_components(pool_map, predicted_components):
-    """
-    Predict the structured references for all the references of
-    one document.
-    """
-    reference_ids = list(set([
-        comp['Reference id'] for comp in predicted_components]
-    ))
-
-    # We group components by reference before merging
-    references_components = [
-        [
-            comp for comp in predicted_components 
-            if comp['Reference id']==reference_id
-        ]
-        for reference_id in reference_ids
-    ]
-
-    merged_components = pool_map(
-        decide_components,
-        references_components
-    )
-
-    for i, reference_components in enumerate(merged_components):
-        reference_components.update({
-            'Reference id': reference_ids[i]
-        })
-
-    # logger.info("[+] Reference structure predicted")
-    return merged_components
-
-
-def _predict_component(model, word_list):
-    # To test what individual things predict,
-    # it can deal with a list input or not
-    # The maximum probability found is the probability
-    # of the predicted classification
-
-    component_prediction = model.predict(word_list)
-    component_prediction_probabilities = model.predict_proba(word_list)
-    component_prediction_probability = [
-        p.max() for p in component_prediction_probabilities
-    ]
-
-    return component_prediction[0], component_prediction_probability[0]
-
-
 def is_year(component):
     valid_years_range = range(1800, 2020)
     if len(component) == 6:
@@ -144,28 +83,11 @@ def is_year(component):
     return component.isdecimal() and int(component) in valid_years_range
 
 
-def predict_component(component, model):
-
-    if is_year(component):
-        pred_cat = 'PubYear'
-        pred_prob = 1
-    else:
-        pred_cat, pred_prob = _predict_component(
-            model,
-            [component]
-        )
-
-    return {
-        'Predicted Category': pred_cat,
-        'Prediction Probability': pred_prob
-    }
-
-def predict_components(pool_map, model, reference_components):
+def predict_components(model, reference_components):
 
     """
     Predicts the categories for a list of reference components.
     Input:
-    - pool_map: Pool map used for multiprocessing the predicting
     - model: The trained multinomial naive Bayes model for predicting the categories of reference components
     - reference_components: A list of reference components
     Output:
@@ -176,44 +98,41 @@ def predict_components(pool_map, model, reference_components):
     #     "[+] Predicting the categories of %s  reference components ...",
     #     str(len(reference_components))
     # )
+    if not reference_components:
+        return []
 
-    predictions = list(pool_map(
-        partial(predict_component,
-                model=model),
-        [comp['Reference component'] for comp in reference_components]
-    ))
-
+    component_predictions = model.predict(reference_components)
+    component_predictions_probs = [
+        p.max() for p in model.predict_proba(reference_components)
+    ]
+    
     predicted_components = []
-    for i, predicted_component in enumerate(predictions):
+    for i, component in enumerate(reference_components):
+        if is_year(component):
+            cat = 'PubYear'
+            prob = 1
+        else:
+            cat = component_predictions[i]
+            prob = component_predictions_probs[i]
+
         predicted_components.append({
-            'Reference id': reference_components[i]['Reference id'],
-            'Reference component': reference_components[i]['Reference component'],
-            'Predicted Category': predicted_component['Predicted Category'],
-            'Prediction Probability': predicted_component['Prediction Probability']
+            'Reference component': component,
+            'Predicted Category': cat,
+            'Prediction Probability': prob
         })
 
     # logger.info("Predictions complete")
-
     return predicted_components
 
 
-def structure_references(pool_map, model, splitted_references):
-    splitted_components = split_references(splitted_references)
-
-    # TO DO: Rather than just skip,
-    # return empty lists in predict_references, predict_structure and fuzzy_match_blocks
-    if len(splitted_components) == 0:
-        return []
+def structure_reference(model, reference):
+    splitted_components = split_reference(reference)
 
     predicted_components = predict_components(
-        pool_map,
         model,
         splitted_components
     )
 
-    structured_references = merge_components(
-        pool_map,
-        predicted_components
-    )
+    structured_reference = merge_components(predicted_components)
     
-    return structured_references
+    return structured_reference

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -1,7 +1,10 @@
+import datetime
+import re
+
 from settings import settings
 
-logger = settings.logger
 
+VALID_YEARS = (1800, datetime.date.today().year + 1)
 
 def split_reference(reference):
     """Split up one individual reference into reference components.
@@ -63,14 +66,12 @@ def merge_components(reference_components):
 
 
 def is_year(component):
-    valid_years_range = range(1800, 2020)
     if len(component) == 6:
         component = component[1:5]
-    return component.isdecimal() and int(component) in valid_years_range
+    return component.isdecimal() and VALID_YEARS[0] <= int(component) < VALID_YEARS[1]
 
 
 def predict_components(model, reference_components):
-
     """
     Predicts the categories for a list of reference components.
     Input:

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -81,10 +81,6 @@ def predict_components(model, reference_components):
     - A list of dicts [{"Predicted Category": , "Prediction Probability": } ...]
     """
 
-    # logger.info(
-    #     "[+] Predicting the categories of %s  reference components ...",
-    #     str(len(reference_components))
-    # )
     if not reference_components:
         return []
 
@@ -108,7 +104,6 @@ def predict_components(model, reference_components):
             'Prediction Probability': prob
         })
 
-    # logger.info("Predictions complete")
     return predicted_components
 
 

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -42,7 +42,7 @@ def split_references(references):
                 'Reference id': reference['Reference id']
             })
 
-    logger.info("Reference components found")
+    # logger.info("Reference components found")
     return raw_reference_components
 
 
@@ -118,7 +118,7 @@ def merge_components(pool_map, predicted_components):
             'Reference id': reference_ids[i]
         })
 
-    logger.info("[+] Reference structure predicted")
+    # logger.info("[+] Reference structure predicted")
     return merged_components
 
 
@@ -172,10 +172,10 @@ def predict_components(pool_map, model, reference_components):
     - A list of dicts [{"Predicted Category": , "Prediction Probability": } ...]
     """
 
-    logger.info(
-        "[+] Predicting the categories of %s  reference components ...",
-        str(len(reference_components))
-    )
+    # logger.info(
+    #     "[+] Predicting the categories of %s  reference components ...",
+    #     str(len(reference_components))
+    # )
 
     predictions = list(pool_map(
         partial(predict_component,
@@ -192,7 +192,7 @@ def predict_components(pool_map, model, reference_components):
             'Prediction Probability': predicted_component['Prediction Probability']
         })
 
-    logger.info("Predictions complete")
+    # logger.info("Predictions complete")
 
     return predicted_components
 

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -8,11 +8,15 @@ def split_reference(reference):
     """Split up one individual reference into reference components.
     Each component is numbered by the reference it came from.
     """
+    if not reference:
+        return []
+
     components = []
 
     # I need to divide each reference by the full stops
     # AND commas and categorise
     reference_sentences_mid = [
+        # Notice that we remove spaces for elem
         elem.strip()
         for elem in reference.replace(
             ',', '.'

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -1,4 +1,3 @@
-from functools import partial
 from settings import settings
 
 logger = settings.logger

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -10,25 +10,8 @@ def split_reference(reference):
     if not reference:
         return []
 
-    components = []
-
-    # I need to divide each reference by the full stops
-    # AND commas and categorise
-    reference_sentences_mid = [
-        # Notice that we remove spaces for elem
-        elem.strip()
-        for elem in reference.replace(
-            ',', '.'
-        ).replace(
-            '?', '?.'
-        ).replace(
-            '!', '!.'
-        ).split(".")
-    ]
-
-    for ref in reference_sentences_mid:
-        if ref:
-            components.append(ref)
+    # To do: Check whether removing strip is having an impact
+    components = [elem.strip() for elem in re.split('[,?!.]', reference)]
 
     return components
 

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -40,9 +40,7 @@ def process_references(references):
         for component in components:
             raw_reference_components.append({
                 'Reference component': component,
-                'Reference id': reference['Reference id'],
-                'Document uri': reference['Document uri'],
-                'Document id': reference['Document id']
+                'Reference id': reference['Reference id']
             })
 
     logger.info("Reference components found")
@@ -103,8 +101,7 @@ def decide_components(single_reference):
     return single_reference_components
 
 
-def predict_structure(pool_map, reference_components_predictions,
-                      prediction_probability_threshold):
+def predict_structure(pool_map, reference_components_predictions):
     """
     Predict the structured references for all the references of
     one document.
@@ -120,13 +117,9 @@ def predict_structure(pool_map, reference_components_predictions,
         decide_components,
         document_components_list
     )
-    
-    document_id = reference_components_predictions[0]['Document id']
-    document_uri = reference_components_predictions[0]['Document uri']
+
     for i, ref in enumerate(doc_references):
         ref.update({
-            'Document id': document_id,
-            'Document uri': document_uri,
             'Reference id': reference_ids[i]
         })
 
@@ -235,7 +228,7 @@ def structure_references(pool_map, model, splitted_references):
     # Predict the reference structure
     predicted_reference_structures = predict_structure(
         pool_map,
-        reference_components_predictions,
-        settings.PREDICTION_PROBABILITY_THRESHOLD
+        reference_components_predictions
     )
+    
     return predicted_reference_structures

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -151,12 +151,8 @@ def single_reference_structure(components_single_reference,
     return single_reference
 
 
-def _get_structure(reference_id, document):
+def _get_structure(components_single_reference):
     # The components and predictions for one document one reference
-
-    components_single_reference = document.loc[
-        document['Reference id'] == reference_id
-    ].reset_index()
 
     # Structure:
     single_reference = single_reference_structure(
@@ -170,15 +166,15 @@ def _get_structure(reference_id, document):
         # high prediction probabilies
         single_reference[
             "Document id"
-        ] = components_single_reference['Document id'][0]
+        ] = components_single_reference['Document id'].iloc[0]
 
         single_reference[
             "Reference id"
-        ] = components_single_reference['Reference id'][0]
+        ] = components_single_reference['Reference id'].iloc[0]
 
         single_reference[
             "Document uri"
-        ] = components_single_reference['Document uri'][0]
+        ] = components_single_reference['Document uri'].iloc[0]
 
     return pd.DataFrame.from_dict(single_reference)
 
@@ -193,10 +189,16 @@ def predict_structure(pool_map, reference_components_predictions,
     # Convert to pd dataframe, although when this function is refactored we shouldnt have to do this
     reference_components_predictions = pd.DataFrame.from_dict(reference_components_predictions)
 
+    document_components_list = [
+        reference_components_predictions.loc[
+            reference_components_predictions['Reference id'] == reference_id
+        ]
+        for reference_id in reference_components_predictions['Reference id'].unique()
+    ]
+
     doc_references = pool_map(
-        partial(_get_structure,
-                document=reference_components_predictions),
-        reference_components_predictions['Reference id']
+        _get_structure,
+        document_components_list
     )
 
     logger.info("[+] Reference structure predicted")

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -185,49 +185,22 @@ def _get_structure(reference_id, document):
 
 def predict_structure(pool_map, reference_components_predictions,
                       prediction_probability_threshold):
-    """Predict the structured references for all the references. Go through
-    each reference for each document in turn.
+    """
+    Predict the structured references for all the references of
+    one document.
     """
 
     # Convert to pd dataframe, although when this function is refactored we shouldnt have to do this
     reference_components_predictions = pd.DataFrame.from_dict(reference_components_predictions)
 
-    all_structured_references = []
-    document_ids = set(reference_components_predictions['Document id'])
-
-    logger.info(
-        "[+] Predicting structure of references from %s  documents...",
-        str(len(document_ids))
-    )
-    for document_id in document_ids:
-        document = reference_components_predictions.loc[
-            reference_components_predictions['Document id'] == document_id
-        ]
-
-        reference_ids = set(document['Reference id'])
-
-        # doc_references = map(
-        #     lambda x: _get_structure(x, document),
-        #     reference_ids
-        # )
-        doc_references = pool_map(
-            partial(_get_structure,
-                    document=document),
-            reference_ids
-        )
-        all_structured_references.extend(
-            doc_references
-        )
-
-    all_structured_references = pd.concat(
-        all_structured_references,
-        axis=0,
-        ignore_index=True,
-        sort=False
+    doc_references = pool_map(
+        partial(_get_structure,
+                document=reference_components_predictions),
+        reference_components_predictions['Reference id']
     )
 
     logger.info("[+] Reference structure predicted")
-    return all_structured_references
+    return pd.concat(doc_references)
 
 
 def predict_reference_comp(model, word_list):

--- a/utils/predict.py
+++ b/utils/predict.py
@@ -221,19 +221,9 @@ def predict_reference_comp(model, word_list):
 
 def is_year(component):
     valid_years_range = range(1800, 2020)
-    return (
-                (
-                    component.isdecimal()
-                    and int(component) in valid_years_range
-                )
-                or
-                (
-                    len(component) == 6
-                    and component[1:5].isdecimal()
-                    and int(component[1:5]) in valid_years_range
-                )
-            )
-        
+    if len(component) == 6:
+        component = component[1:5]
+    return component.isdecimal() and int(component) in valid_years_range
 
 def _get_component(component, model):
 

--- a/utils/split.py
+++ b/utils/split.py
@@ -32,7 +32,7 @@ def split_section(references_section, regex="\n"):
     return references
 
 
-def process_references_section(doc, regex):
+def split_references_section(doc, regex):
     """Converts the unstructured text into reference components
     Input:
     - a SectionedDocument tuple

--- a/utils/split.py
+++ b/utils/split.py
@@ -32,10 +32,10 @@ def split_section(references_section, regex="\n"):
     return references
 
 
-def split_references_section(doc, regex):
+def split_references_section(section, regex):
     """Converts the unstructured text into reference components
     Input:
-    - a SectionedDocument tuple
+    - a References section string
     Output:
     - A list of references data which come into a dict with keys
         about the reference string, reference id, document uri and
@@ -52,13 +52,10 @@ def split_references_section(doc, regex):
     # Eric, 1987
 
     references_data = []
-    references = split_section(doc.section, regex)
+    references = split_section(section, regex)
     for reference in references:
         references_data.append({
             'Reference': reference,
-            'Reference id': hash(reference),
-            # TODO: remove these
-            'Document uri': doc.uri,
-            'Document id': doc.id,
+            'Reference id': hash(reference)
         })
     return references_data

--- a/utils/split.py
+++ b/utils/split.py
@@ -2,14 +2,17 @@
 
 import re
 
-from settings import settings
 
-logger = settings.logger
-
-
-def _split_section(references_section, regex="\n"):
-    """
-    Split up a raw text reference section into individual references
+def split_section(references_section, regex="\n"):
+    """Converts the unstructured text into reference components
+    Input:
+    - a References section string
+    Output:
+    - A list of references data which come into a dict with keys
+        about the reference string, reference id, document uri and
+        document id
+    Nomenclature:
+    Document > References
     """
     references = re.split(regex, references_section)
     # Remove any row with less than 10 characters in
@@ -30,32 +33,3 @@ def _split_section(references_section, regex="\n"):
     ]
 
     return references
-
-
-def split_section(section, regex):
-    """Converts the unstructured text into reference components
-    Input:
-    - a References section string
-    Output:
-    - A list of references data which come into a dict with keys
-        about the reference string, reference id, document uri and
-        document id
-    Nomenclature:
-    Document > References
-    """
-    assert section, "references section is empty"
-
-    # e.g.
-    # Document 1:
-    # \n1.\n Smith, et al, 2000 \n2.\n Jones, 1998
-    # Document 2:
-    # Eric, 1987
-
-    references_data = []
-    references = _split_section(section, regex)
-    for reference in references:
-        references_data.append({
-            'Reference': reference,
-            'Reference id': hash(reference)
-        })
-    return references_data

--- a/utils/split.py
+++ b/utils/split.py
@@ -7,7 +7,7 @@ from settings import settings
 logger = settings.logger
 
 
-def split_section(references_section, regex="\n"):
+def _split_section(references_section, regex="\n"):
     """
     Split up a raw text reference section into individual references
     """
@@ -32,7 +32,7 @@ def split_section(references_section, regex="\n"):
     return references
 
 
-def split_references_section(section, regex):
+def split_section(section, regex):
     """Converts the unstructured text into reference components
     Input:
     - a References section string
@@ -43,7 +43,7 @@ def split_references_section(section, regex):
     Nomenclature:
     Document > References
     """
-    assert doc.section, "document section is empty"
+    assert section, "references section is empty"
 
     # e.g.
     # Document 1:
@@ -52,7 +52,7 @@ def split_references_section(section, regex):
     # Eric, 1987
 
     references_data = []
-    references = split_section(section, regex)
+    references = _split_section(section, regex)
     for reference in references:
         references_data.append({
             'Reference': reference,


### PR DESCRIPTION
This is one of the biggest refactor to date so please do review and call out any problems.

This refactor aims to achieve a couple of goals
* Remove use of pandas from predict (now named parse)
* Write tests for predict (now named parse)
* Rename variables, functions and files to make the code more readable and names more consistent
* Remove the need to document id and reference id information inside predict (now parse)
* Introduce a high level parse function called structure_reference that a accept a reference and returnes structured references
* Refactor functions in predict so that they work in one reference at at time and the code in refparse to deal with that
* Silence logger to make what is printed out less noisy but still informative

This is a big change but one that I wanted us to do for a couple of months. As a side effect of that change the code runs ~20x faster. Weirdly when I reintroduced pool map in my last commit it slowed things down so I would like to understand why with you @hblanks or @SamDepardieu.

Finally, the idea is that all these changes do move us towards the right direction so if you have second thoughts about any of the above, please do raise them.