### PR TITLE
Add a pdf parsing task to the policy-tool DAG

### DIFF
--- a/docs/s3-layout.md
+++ b/docs/s3-layout.md
@@ -23,6 +23,7 @@ At any time, there will be multiple DAGs running for the policy tool,
 including:
 
 1. `policytool-scrape`: scrapes all policy organizations.
+1. `policytool-parse`: parse all the scraped pdf from policy organizations.
 1. `policytool-epmc-pubs`: fetches publications from EPMC.
 1. `policytool-match-dimensions-pubs`: matches publications from dimensions
 1. `policytool-match-epmc-pubs`: matches publications from EPMC
@@ -47,6 +48,26 @@ So, some example S3 outputs for this DAG are:
 s3://${BUCKET_NAME}/airflow/output/policytool-scrape/scraper-who/policytool-scrape--scraper-who.json.gz
 s3://${BUCKET_NAME}/airflow/output/policytool-scrape/scraper-who/pdf/0a/0a4cb4bebf2a177e43dc36274820880cdcacb2.pdf
 s3://${BUCKET_NAME}/airflow/output/policytool-scrape/summary/policytool-scrape--summary.json.gz
+```
+
+## `policytool.parse`
+
+There's one task per organization in `policytool.parse`. Task names would include:
+
+- `parser-who`
+- `parser-msf`
+- `parser-govuk`
+
+A final task may also be added to summarize their results into a single output:
+
+- `summary`
+
+So, some example S3 outputs for this DAG are:
+
+```
+s3://${BUCKET_NAME}/airflow/output/policytool-parse/parser-who/policytool-scrape--parser-who.json.gz
+s3://${BUCKET_NAME}/airflow/output/policytool-parse/parser-who/pdf/0a/0a4cb4bebf2a177e43dc36274820880cdcacb2.pdf
+s3://${BUCKET_NAME}/airflow/output/policytool-parse/summary/policytool-scrape--summary.json.gz
 ```
 
 ## `policytool-epmc-pubs`
@@ -84,7 +105,7 @@ scraper-${ORGANIZATION} --------------------> refparser-${ORGANIZATION}
 (from policytool.scrape)                       |
                                                |
                                                v
-publications -------------------------------> matcher-${ORGANIZATION} 
+publications -------------------------------> matcher-${ORGANIZATION}
 (from policytool.epmc-pubs or outside DAG)     |
                                                |
                                                v
@@ -96,8 +117,8 @@ Key steps:
 1. A scraper, in the `policytool-scrape` DAg, pulls PDF from an organization's
    websites, storing each of them to S3 and writing a `manifest.json` file
    containing the list of all scraped PDFs and other metadata.
-1. A refparser extracts references from all PDFs listed by a 
-   `manifest.json` and writes them to an output `references.json` 
+1. A refparser extracts references from all PDFs listed by a
+   `manifest.json` and writes them to an output `references.json`
    file.
 1. A matcher reads from all publications, and from a `references.json`,
    producing matched referencies (citations) and writing them to an
@@ -125,4 +146,3 @@ s3://${BUCKET_NAME}/airflow/output/policytool-match-epmc-pubs/matcher-msf/
 s3://${BUCKET_NAME}/airflow/output/policytool-match-epmc-pubs/concat-matches/
     policytool-match-epmc-pubs--concat-matches.json.gz
 ```
-

--- a/policytool/Dockerfile
+++ b/policytool/Dockerfile
@@ -6,6 +6,7 @@ FROM web-scraper.base
 COPY setup.py /src/policytool/
 COPY README.md /src/policytool/
 COPY scraper/ /src/policytool/scraper/
+COPY pdf_parser/ /src/policytool/pdf_parser/
 
 COPY ./entrypoint.sh /entrypoint.sh
 

--- a/policytool/docker-compose.yml
+++ b/policytool/docker-compose.yml
@@ -55,5 +55,6 @@ services:
     volumes:
       - ./scraper/airflow/airflow.cfg:/airflow/airflow.cfg
       - ./scraper:/src/policytool/scraper/
+      - ./pdf_parser:/src/policytool/pdf_parser/
       - ./resources:/src/policytool/resources/
       - ./build/airflow.db:/airflow/db

--- a/policytool/pdf_parser/pdf_parse.py
+++ b/policytool/pdf_parser/pdf_parse.py
@@ -39,7 +39,7 @@ def parse_pdf_document(document):
             document.name,
             e.stderr,
         )
-        return None
+        return None, None
 
     try:
         # Try to get file stats in order to check both its existance
@@ -51,13 +51,13 @@ def parse_pdf_document(document):
             raise
 
         logger.warning('Error trying to open the parsed file: %s', e)
-        return None
+        return None, None
 
     if st.st_size == 0:
         logger.warning(
             'Error trying to open the parsed file: The file is empty'
         )
-        return None
+        return None, None
 
     with open(parsed_path, 'rb') as html_file:
         soup = bs(html_file.read(), 'html.parser')

--- a/policytool/pdf_parser/pdf_parse.py
+++ b/policytool/pdf_parser/pdf_parse.py
@@ -64,6 +64,7 @@ def parse_pdf_document(document):
 
     file_pages = []
     pages = soup.find_all('page')
+    full_text = soup.text
 
     for num, page in enumerate(pages):
         words = page.find_all('text')
@@ -98,7 +99,7 @@ def parse_pdf_document(document):
     pdf_file = PdfFile(file_pages)
     html_file.close()
     os.remove(parsed_path)
-    return pdf_file
+    return pdf_file, full_text
 
 
 def grab_section(pdf_file, keyword):

--- a/policytool/scraper/airflow/dags/policytool_dag.py
+++ b/policytool/scraper/airflow/dags/policytool_dag.py
@@ -3,20 +3,20 @@ DAG to run the policy tool on every organisation.
 """
 
 import datetime
-
+import os
 from airflow import DAG
 import airflow.utils.dates
 
 from scraper.airflow.tasks.run_spiders_operator import RunSpiderOperator
-
+from scraper.airflow.tasks.parse_pdf_operator import ParsePdfOperator
 
 ORGANISATIONS = [
     'who_iris',
     'nice',
     'gov_uk',
-    'msf',
     'unicef',
     'parliament',
+    'msf',
 ]
 
 args = {
@@ -32,10 +32,37 @@ dag = DAG(
     schedule_interval='0 0 * * 0'
 )
 
-
 for organisation in ORGANISATIONS:
+    scraping_path = os.path.join(
+        'datalabs-data',
+        'airflow',
+        'output',
+        'policytool-scrape',
+        'scraper-{organisation}'.format(
+            organisation=organisation
+        ),
+    )
     run_spider = RunSpiderOperator(
         task_id='run_{spider}_spider'.format(spider=organisation),
         organisation=organisation,
+        path=scraping_path,
         dag=dag,
     )
+
+    parsing_path = os.path.join(
+        'datalabs-data',
+        'airflow',
+        'output',
+        'policytool-parse',
+        'parser-{organisation}'.format(
+            organisation=organisation
+        ),
+    )
+    pdfParsing = ParsePdfOperator(
+        task_id='run_{organisation}_parser'.format(organisation=organisation),
+        organisation=organisation,
+        input_path=scraping_path,
+        output_path=parsing_path,
+        dag=dag,
+    )
+    pdfParsing.set_upstream(run_spider)

--- a/policytool/scraper/airflow/tasks/parse_pdf_operator.py
+++ b/policytool/scraper/airflow/tasks/parse_pdf_operator.py
@@ -7,7 +7,7 @@ import logging
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from pdf_parser.main import parse_pdfs
+from pdf_parser.main import parse_all_pdf
 
 
 logger = logging.getLogger(__name__)
@@ -41,4 +41,4 @@ class ParsePdfOperator(BaseOperator):
         output = 'manifests3://{path}'.format(
             path=self.output_path,
         )
-        parse_pdfs(input, output, RESOURCE_FILES, self.organisation, 2)
+        parse_all_pdf(input, output, RESOURCE_FILES, self.organisation, 2)

--- a/policytool/scraper/airflow/tasks/parse_pdf_operator.py
+++ b/policytool/scraper/airflow/tasks/parse_pdf_operator.py
@@ -1,0 +1,44 @@
+"""
+Operator to run the web scraper on every organisation.
+"""
+import os
+import logging
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from pdf_parser.main import parse_pdfs
+
+
+logger = logging.getLogger(__name__)
+
+RESOURCE_FILES = '/src/policytool/resources/'
+
+
+class ParsePdfOperator(BaseOperator):
+    """
+    Pulls data from the dimensions.ai to a bucket in S3.
+
+    Args:
+        organisation: The organisation to pull documents from.
+    """
+
+    @apply_defaults
+    def __init__(self, organisation, input_path, output_path, *args, **kwargs):
+        super(ParsePdfOperator, self).__init__(*args, **kwargs)
+        self.organisation = organisation
+        self.input_path = input_path
+        self.output_path = output_path
+
+    def execute(self, context):
+        os.environ.setdefault(
+            'SCRAPY_SETTINGS_MODULE',
+            'scraper.wsf_scraping.settings'
+        )
+        input = 'manifests3://{path}'.format(
+            path=self.input_path,
+        )
+        output = 'manifests3://{path}'.format(
+            path=self.output_path,
+        )
+        parse_pdfs(input, output, RESOURCE_FILES, self.organisation, 2)

--- a/policytool/scraper/airflow/tasks/run_spiders_operator.py
+++ b/policytool/scraper/airflow/tasks/run_spiders_operator.py
@@ -40,26 +40,18 @@ class RunSpiderOperator(BaseOperator):
     """
 
     @apply_defaults
-    def __init__(self, organisation, *args, **kwargs):
+    def __init__(self, organisation, path, *args, **kwargs):
         super(RunSpiderOperator, self).__init__(*args, **kwargs)
         self.organisation = organisation
+        self.path = path
 
     def execute(self, context):
         os.environ.setdefault(
             'SCRAPY_SETTINGS_MODULE',
             'scraper.wsf_scraping.settings'
         )
-        path = os.path.join(
-            'datalabs-data',
-            'airflow',
-            'output',
-            'policytool-scrape',
-            'scraper-{organisation}'.format(
-                organisation=self.organisation
-            ),
-        )
         scraper.wsf_scraping.settings.FEED_URI = 'manifests3://{path}'.format(
-            path=path
+            path=self.path
         )
 
         settings = get_project_settings()

--- a/policytool/scraper/wsf_scraping/file_system.py
+++ b/policytool/scraper/wsf_scraping/file_system.py
@@ -31,7 +31,7 @@ class FileSystem(ABC):
         Returns:
             - path: The full path of the saved file.
         """
-        return
+        pass
 
     @abstractmethod
     def get_manifest(self):
@@ -40,7 +40,7 @@ class FileSystem(ABC):
         Args:
             - organisation: A string representing the name of the organisation.
         """
-        return
+        pass
 
     @abstractmethod
     def update_manifest(self, data_file):
@@ -49,7 +49,7 @@ class FileSystem(ABC):
         Args:
             - data_file: The file object sent by Scrapy's feed storage.
         """
-        return
+        pass
 
     @abstractmethod
     def get(self, file_hash):
@@ -57,7 +57,7 @@ class FileSystem(ABC):
         Args:
             - file_hash: The md5 digest of the file to retrieve.
         """
-        return
+        pass
 
 
 class S3FileSystem(FileSystem):
@@ -97,10 +97,10 @@ class S3FileSystem(FileSystem):
             if response.get('Body'):
                 return json.loads(response['Body'].read())
             else:
-                return dict()
+                return {}
         except ClientError as e:
             if e.response['Error']['Code'] == 'NoSuchKey':
-                return dict()
+                return {}
             else:
                 raise
 
@@ -134,9 +134,12 @@ class S3FileSystem(FileSystem):
                 Bucket=self.bucket,
                 Key=key,
             )
-            return response['Body']
+            if response.get('Body'):
+                return response['Body']
         except ClientError as e:
             raise e
+
+        return None
 
 
 class LocalFileSystem(FileSystem):
@@ -189,4 +192,4 @@ class LocalFileSystem(FileSystem):
             with open(os.path.join(self.prefix, key), 'rb') as pdf:
                 return pdf
         else:
-            return {}
+            return None

--- a/policytool/scraper/wsf_scraping/pipelines.py
+++ b/policytool/scraper/wsf_scraping/pipelines.py
@@ -95,7 +95,7 @@ class WsfScrapingPipeline(object):
                 item['hash'][:2],
             )
             with open(item['pdf'], 'rb') as pdf:
-                self.storage.save(pdf.read(), path, item['hash'])
+                self.storage.save(pdf, path, item['hash'])
         else:
             raise DropItem(
                 'This pdf is already in the manifest file.'

--- a/policytool/scraper/wsf_scraping/pipelines.py
+++ b/policytool/scraper/wsf_scraping/pipelines.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import logging
 from urllib.parse import urlparse
 from scrapy.utils.project import get_project_settings
@@ -89,7 +90,12 @@ class WsfScrapingPipeline(object):
         in_manifest = self.is_in_manifest(item['hash'])
 
         if not in_manifest:
-            self.storage.save(item['pdf'], item['hash'])
+            path = os.path.join(
+                'pdf',
+                item['hash'][:2],
+            )
+            with open(item['pdf'], 'rb') as pdf:
+                self.storage.save(pdf.read(), path, item['hash'])
         else:
             raise DropItem(
                 'This pdf is already in the manifest file.'


### PR DESCRIPTION
# Description

This pr aims to bring the next task on the policytool pipeline: parsing the scraped pdfs.

To achieve this:
 - Rework the pdf parser module to make it task friendly:
  - Now has a `main.py` file callable both from airflow or with arguments from the console
  - The main file reads all pdf locations from a manifest (either locally stored or on s3), download them and extract their sections, keywords and text. It then store them in a json file on the given output location.
 - Create a parser operator for airflow
 - Add parsing tasks for each organisations in airflow  

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

Mac OSx 10.14.2 / Python 3.6:
 - Local runs
 - Unit testing

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
~~- [ ] I included tests in my PR~~ N/A
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
~~- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`~~ N/A
