### PR TITLE
Add hard text search to Policy Tool

### DIFF
--- a/refparse.py
+++ b/refparse.py
@@ -98,20 +98,20 @@ def get_file(file_str, file_type, get_scraped=False):
 def remove_dups_and_concat(fuzzy_matches, text_matches):
     #Remove duplicate columns and short matches in the fuzzy matches
     fuzzy_matches = fuzzy_matches.loc[:,~fuzzy_matches.columns.duplicated()]
-    fuzzy_matches = fuzzy_matches.loc[fuzzy_matches['WT_Ref_Title'].str.len() >= settings.FUZZY_MATCH_CHAR_LIMIT]
+    fuzzy_matches = fuzzy_matches.loc[fuzzy_matches['WT_Ref_Title'].str.len() >= settings.MIN_CHAR_LIMIT]
 
-    if not text_matches.empty:
-        duplicate_matches = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
-
-        #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
-        text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_matches)]
-        fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_matches)] = "Fuzzy and Text Searches"
-
-        all_matches = pd.concat([fuzzy_matches, text_matches])
-        return (all_matches)
+    if text_matches.empty:
+        return fuzzy_matches
 
     else:
-        return (fuzzy_matches)
+        duplicate_ref_ids = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
+
+        #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
+        text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_ref_ids)]
+        fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_ref_ids)] = "Fuzzy and Text Searches"
+
+        all_matches = pd.concat([fuzzy_matches, text_matches])
+        return all_matches
 
 
 def run_predict(scraper_file, references_file,

--- a/refparse.py
+++ b/refparse.py
@@ -102,14 +102,16 @@ def remove_dups_and_concat(fuzzy_matches, text_matches):
 
     if not text_matches.empty:
         duplicate_matches = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
-
+        print(duplicate_matches)
         #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
         text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_matches)]
-        fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_matches)] = "Fuzzy Matcher and Hard Text"
+        fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_matches)] = "Fuzzy and Text Searches"
 
-    all_matches = pd.concat([fuzzy_matches, text_matches])
+        all_matches = pd.concat([fuzzy_matches, text_matches])
+        return (all_matches)
 
-    return(all_matches)
+    else:
+        return (fuzzy_matches)
 
 
 def run_predict(scraper_file, references_file,

--- a/refparse.py
+++ b/refparse.py
@@ -109,7 +109,7 @@ def remove_dups_and_concat(fuzzy_matches, text_matches):
 
     #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
     text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_ref_ids)]
-    fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_ref_ids)] = "Fuzzy and Text Searches"
+    fuzzy_matches.at[fuzzy_matches['WT_Ref_Id'].isin(duplicate_ref_ids), 'Match_algorithm'] = "Fuzzy and Text Searches"
 
     all_matches = pd.concat([fuzzy_matches, text_matches])
     return all_matches

--- a/refparse.py
+++ b/refparse.py
@@ -103,15 +103,14 @@ def remove_dups_and_concat(fuzzy_matches, text_matches):
     if text_matches.empty:
         return fuzzy_matches
 
-    else:
-        duplicate_ref_ids = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
+    duplicate_ref_ids = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
 
-        #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
-        text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_ref_ids)]
-        fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_ref_ids)] = "Fuzzy and Text Searches"
+    #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
+    text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_ref_ids)]
+    fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_ref_ids)] = "Fuzzy and Text Searches"
 
-        all_matches = pd.concat([fuzzy_matches, text_matches])
-        return all_matches
+    all_matches = pd.concat([fuzzy_matches, text_matches])
+    return all_matches
 
 
 def run_predict(scraper_file, references_file,

--- a/refparse.py
+++ b/refparse.py
@@ -102,7 +102,7 @@ def remove_dups_and_concat(fuzzy_matches, text_matches):
 
     if not text_matches.empty:
         duplicate_matches = fuzzy_matches['WT_Ref_Id'][fuzzy_matches['WT_Ref_Id'].isin(text_matches['WT_Ref_Id'])]
-        print(duplicate_matches)
+
         #For duplicate matches: remove from text_matches, and renames 'Match_algorithm' in fuzzy_matches
         text_matches = text_matches[~text_matches['WT_Ref_Id'].isin(duplicate_matches)]
         fuzzy_matches['Match_algorithm'][fuzzy_matches['WT_Ref_Id'].isin(duplicate_matches)] = "Fuzzy and Text Searches"

--- a/refparse.py
+++ b/refparse.py
@@ -98,7 +98,9 @@ def get_file(file_str, file_type, get_scraped=False):
 def remove_dups_and_concat(fuzzy_matches, text_matches):
     #Remove duplicate columns and short matches in the fuzzy matches
     fuzzy_matches = fuzzy_matches.loc[:,~fuzzy_matches.columns.duplicated()]
-    fuzzy_matches = fuzzy_matches.loc[fuzzy_matches['WT_Ref_Title'].str.len() >= settings.MIN_CHAR_LIMIT]
+
+    if not fuzzy_matches.empty:
+        fuzzy_matches = fuzzy_matches.loc[fuzzy_matches['WT_Ref_Title'].str.len() >= settings.MIN_CHAR_LIMIT]
 
     if text_matches.empty:
         return fuzzy_matches

--- a/refparse.py
+++ b/refparse.py
@@ -16,7 +16,9 @@ import pandas as pd
 from utils import (FileManager,
                    FuzzyMatcher,
                    split_section,
-                   structure_reference)
+                   structure_reference,
+                   clean_series_text,
+                   hard_text_search)
 from models import DatabaseEngine
 from settings import settings
 
@@ -118,6 +120,11 @@ def run_predict(scraper_file, references_file,
     ref_file = get_file(references_file, 'csv')
     check_references_file(ref_file, references_file)
 
+    clean_ref_file = pd.DataFrame({
+        'uber_id' : ref_file['uber_id'],
+        'title' : clean_series_text(ref_file['title'])
+    })
+    
     # Loading the pipeline
     model = get_file(model_file, 'pickle')
 
@@ -158,6 +165,12 @@ def run_predict(scraper_file, references_file,
 
         matched_references = fuzzy_matcher.fuzzy_match(
             structured_references
+        )
+
+        matched_references = hard_text_search(
+            doc,
+            clean_ref_file,
+            matched_references
         )
 
         if output_url.startswith('file://'):

--- a/settings.py
+++ b/settings.py
@@ -31,6 +31,9 @@ class BaseSettings:
 
     ORGANISATION_REGEX = "\\n[\d\.\s\\n]+(?=[A-Z])"
 
+    FUZZY_MATCH_CHAR_LIMIT = 20
+    HARD_TEXT_CHAR_LIMIT = 40
+
     REF_CLASSES = ['Authors', 'Journal', 'Volume', 'Issue', 'Pagination', 'Title','PubYear']
 
 

--- a/settings.py
+++ b/settings.py
@@ -31,8 +31,8 @@ class BaseSettings:
 
     ORGANISATION_REGEX = "\\n[\d\.\s\\n]+(?=[A-Z])"
 
-    FUZZY_MATCH_CHAR_LIMIT = 20
-    HARD_TEXT_CHAR_LIMIT = 40
+    MIN_CHAR_LIMIT = 20
+    HARD_TEXT_MIN_CHAR_LIMIT = 40
 
     REF_CLASSES = ['Authors', 'Journal', 'Volume', 'Issue', 'Pagination', 'Title','PubYear']
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,7 @@ from .parse import predict_components, merge_components, split_reference, struct
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
+from .hard_text_search import clean_series_text, hard_text_search
 
 __all__ = [
     split_section,
@@ -13,5 +14,7 @@ __all__ = [
     FuzzyMatcher,
     FileManager,
     serialise_matched_reference,
-    serialise_reference
+    serialise_reference,
+    clean_series_text,
+    hard_text_search
 ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,7 +3,7 @@ from .parse import predict_components, merge_components, split_reference, struct
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
-from .hard_text_search import clean_text, hard_text_search
+from .hard_text_search import HardTextSearch
 
 __all__ = [
     split_section,
@@ -15,6 +15,5 @@ __all__ = [
     FileManager,
     serialise_matched_reference,
     serialise_reference,
-    clean_text,
-    hard_text_search
+    HardTextSearch
 ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,7 +3,7 @@ from .parse import predict_components, merge_components, split_reference, struct
 from .fuzzymatch import FuzzyMatcher
 from .file_manager import FileManager
 from .serialiser import serialise_matched_reference, serialise_reference
-from .hard_text_search import clean_series_text, hard_text_search
+from .hard_text_search import clean_text, hard_text_search
 
 __all__ = [
     split_section,
@@ -15,6 +15,6 @@ __all__ = [
     FileManager,
     serialise_matched_reference,
     serialise_reference,
-    clean_series_text,
+    clean_text,
     hard_text_search
 ]

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -24,7 +24,7 @@ class FuzzyMatcher:
                 'title': [],
                 'uber_id': [],
                 'Cosine_Similarity': [],
-                'Tool': []
+                'Match_algorithm': "Fuzzy Matcher"
             })
 
         # Todo - Make sure not resetting index works the same
@@ -61,10 +61,7 @@ class FuzzyMatcher:
             }).reset_index()],
             axis=1)
 
-        match_data['Tool'] = "Parser"
-
-        match_data = match_data.loc[:,~match_data.columns.duplicated()]
-        match_data = match_data.loc[match_data['title'].str.len() >= 20]
+        match_data['Match_algorithm'] = "Fuzzy Matcher"
 
         return match_data
 

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -23,7 +23,8 @@ class FuzzyMatcher:
                 'Title': [],
                 'title': [],
                 'uber_id': [],
-                'Cosine_Similarity': []
+                'Cosine_Similarity': [],
+                'Tool': []
             })
 
         # Todo - Make sure not resetting index works the same
@@ -59,6 +60,10 @@ class FuzzyMatcher:
                 'Cosine_Similarity': cosine_similarities
             }).reset_index()],
             axis=1)
+
+        match_data['Tool'] = "Parser"
+
+        match_data = match_data.loc[:,~match_data.columns.duplicated()]
 
         return match_data
 

--- a/utils/fuzzymatch.py
+++ b/utils/fuzzymatch.py
@@ -64,6 +64,7 @@ class FuzzyMatcher:
         match_data['Tool'] = "Parser"
 
         match_data = match_data.loc[:,~match_data.columns.duplicated()]
+        match_data = match_data.loc[match_data['title'].str.len() >= 20]
 
         return match_data
 

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -1,49 +1,61 @@
 import pandas as pd
 import re
 
+class HardTextSearch:
+	def __init__(self, ref_file, min_chars):
+		#Cleans up the ref file, changing from pandas DF to dict to reduce run time
+		ref_file['title'] = [self.clean_text(x) for x in ref_file['title']]
+		ref_file = ref_file.loc[ref_file['title'].str.len() >= min_chars]
+		ref_file = ref_file.drop_duplicates(subset = 'title')
+		ref_file = ref_file.to_dict(orient = 'list')
 
-def clean_text(string):
-	"""
-	Input:
-	-A string
-	Output:
-	-A string, with white space normalised and
-	 non-alphanumeric characters removed
-	Cleans up text such that it can easily be searched
-	"""
-
-	string = re.sub("\\n", " ", string)
-	string = re.sub("\s{1,}", " ", string)
-	string = re.sub("[^A-Za-z0-9 ]", "", string)
-
-	string = string.lower()
-
-	return (string)
+		self.ref_file = ref_file
 
 
-def hard_text_search(scraped_text, ref_file, matches):
-	"""
-	Input:
-	-Raw scraped text (named tuple, SectionedDocument)
-	-Cleaned references file (dict, converted from pandas DF)
-	-Matches found by the fuzzy matcher (pandas DF)
-	Output:
-	-Extension to matches, with hard text search results concatenated
-	"""
+	def clean_text(self, string):
+		"""
+		Input:
+		-A string
+		Output:
+		-A string, with white space normalised and
+		 non-alphanumeric characters removed
+		Cleans up text such that it can easily be searched
+		"""
 
-	#Adds a flag, showing which process found the match, and removes duplicates
-	matches['Tool'] = "Policy"
-	matches = matches.loc[:,~matches.columns.duplicated()]
+		string = re.sub("\\n", " ", string)
+		string = re.sub("\s{1,}", " ", string)
+		string = re.sub("[^A-Za-z0-9 ]", "", string)
 
-	clean_scraped_text = clean_text(scraped_text.section)
+		string = string.lower()
 
-	for i in range(len(ref_file['title'])):
+		return (string)
 
-		title = ref_file['title'][i]
-		uber_id = ref_file['uber_id'][i]
 
-		#If there are new matches, append all relevant columns to the matched_refs DataFrame
-		if not matches['WT_Ref_Id'].str.contains(uber_id).any():
+	def hard_text_search(self, scraped_text, refs_to_exclude):
+		"""
+		Input:
+		-Raw scraped text (named tuple, SectionedDocument)
+		-IDs of matches already found by fuzzy matcher (pandas Series)
+		Output:
+		-Extension to matches, with hard text search results concatenated
+		"""
+
+		#Removes refs already found by fuzzy matcher
+		indices_to_exclude = [i for i,x in enumerate(self.ref_file['uber_id']) if x in refs_to_exclude]
+		for i in sorted(indices_to_exclude, reverse = True):
+			del self.ref_file['title'][i]
+			del self.ref_file['uber_id'][i]
+
+		clean_scraped_text = self.clean_text(scraped_text.section)
+
+		matches = pd.DataFrame()
+
+		for i in range(len(self.ref_file['title'])):
+
+			title = self.ref_file['title'][i]
+			uber_id = self.ref_file['uber_id'][i]
+
+			#If there are new matches, append all relevant columns to the matched_refs DataFrame
 			if title in clean_scraped_text:
 
 				refs_matched_with_title = {
@@ -58,4 +70,4 @@ def hard_text_search(scraped_text, ref_file, matches):
 
 				matches = matches.append(refs_matched_with_title, ignore_index=True)
 
-	return (matches)
+		return (matches)

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -59,7 +59,7 @@ class HardTextSearch:
 					'Title'             : title,
 					'WT_Ref_Title'      : self.ref_file['title'][i],
 					'WT_Ref_Id'         : self.ref_file['uber_id'][i],
-					'Match_algorithm'   : "Hard Text"
+					'Match_algorithm'   : "Text Search"
 				}
 
 				matches = matches.append(refs_matched_with_title, ignore_index=True)

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -7,7 +7,7 @@ class HardTextSearch:
 	def __init__(self, ref_file):
 		#Cleans up the ref file, changing from pandas DF to dict to reduce run time
 		ref_file['clean_title'] = ref_file['title'].apply(lambda x: self.clean_text(x))
-		ref_file = ref_file.loc[ref_file['clean_title'].str.len() >= settings.HARD_TEXT_CHAR_LIMIT]
+		ref_file = ref_file.loc[ref_file['clean_title'].str.len() >= settings.HARD_TEXT_MIN_CHAR_LIMIT]
 		ref_file = ref_file.drop_duplicates()
 		ref_file = ref_file.to_dict(orient = 'list')
 
@@ -30,7 +30,7 @@ class HardTextSearch:
 
 		string = string.lower()
 
-		return (string)
+		return string
 
 
 	def hard_text_search(self, scraped_text):
@@ -46,9 +46,7 @@ class HardTextSearch:
 
 		matches = pd.DataFrame()
 
-		for i in range(len(self.ref_file['clean_title'])):
-
-			title = self.ref_file['clean_title'][i]
+		for i, title in enumerate(self.ref_file['clean_title']):
 
 			#If there are new matches, append all relevant columns to the matched_refs DataFrame
 			if title in clean_scraped_text:
@@ -64,4 +62,4 @@ class HardTextSearch:
 
 				matches = matches.append(refs_matched_with_title, ignore_index=True)
 
-		return (matches)
+		return matches

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -53,7 +53,7 @@ class HardTextSearch:
 
 				refs_matched_with_title = {
 					'Document id'       : scraped_text.id,
-					'Reference id'      : hash(title),
+					'Reference id'      : hash("UBER_ID:" + str( self.ref_file['uber_id'][i] )),
 					'Title'             : title,
 					'WT_Ref_Title'      : self.ref_file['title'][i],
 					'WT_Ref_Id'         : self.ref_file['uber_id'][i],

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import re
 
-import datetime as dt
-import numpy as np
 
 def clean_text(string):
 	"""

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import re
+
+def clean_series_text(series):
+	"""
+	Input:
+	-A pandas Series containing strings
+	Output:
+	-A pandas Series, with white space normalised and
+	 non-alphanumeric characters removed
+	Cleans up the text in a series such that it can easily be searched
+	"""
+
+	series = series.str.replace(
+			"\\n", " "
+		).str.replace(
+			"\s{1,}", " "
+		).str.replace(
+			"[^A-Za-z0-9 ]", ""
+		).str.lower()
+
+	return (series)
+
+
+def hard_text_search(scraped_text, clean_ref_file, fuzzy_matches):
+	"""
+	Input:
+	-Raw scraped text, string
+	-Cleaned references file, pandas DF
+	-Fuzzy matches, pandas DF
+	Output:
+	-Extension to fuzzy_matches, with hard text search results concatenated
+	"""
+
+	fuzzy_matches['Tool'] = 'Policy'
+
+	clean_scraped_text = clean_series_text(
+		pd.Series(scraped_text.section)
+	).to_frame()
+
+	for _, clean_ref in clean_ref_file.iterrows():
+
+		title = clean_ref['title']
+		id = clean_ref['uber_id']
+
+		#If there are new matches, append all relevant columns to the matched_refs DataFrame
+		if not fuzzy_matches['WT_Ref_Id'].str.contains(id).any():
+			if title in clean_scraped_text.iloc[0,0]:	
+
+				refs_matched_with_title = pd.Series({
+					'Document id'       : scraped_text.id,
+					'Reference id'      : hash(title),
+					'Title'             : title,
+					'WT_Ref_Title'      : title,
+					'WT_Ref_Id'         : id,
+					'Cosine Similarity' : 1,
+					'Tool'              : "Hard Text"
+				}, index = [0])
+
+				fuzzy_matches = fuzzy_matches.loc[:,~fuzzy_matches.columns.duplicated()]
+				fuzzy_matches = fuzzy_matches.append(refs_matched_with_title, ignore_index=True)
+
+	return (fuzzy_matches)

--- a/utils/hard_text_search.py
+++ b/utils/hard_text_search.py
@@ -42,18 +42,19 @@ class HardTextSearch:
 
 		#Removes refs already found by fuzzy matcher
 		indices_to_exclude = [i for i,x in enumerate(self.ref_file['uber_id']) if x in refs_to_exclude]
+		filtered_ref_file = self.ref_file
 		for i in sorted(indices_to_exclude, reverse = True):
-			del self.ref_file['title'][i]
-			del self.ref_file['uber_id'][i]
+			del filtered_ref_file['title'][i]
+			del filtered_ref_file['uber_id'][i]
 
 		clean_scraped_text = self.clean_text(scraped_text.section)
 
 		matches = pd.DataFrame()
 
-		for i in range(len(self.ref_file['title'])):
+		for i in range(len(filtered_ref_file['title'])):
 
-			title = self.ref_file['title'][i]
-			uber_id = self.ref_file['uber_id'][i]
+			title = filtered_ref_file['title'][i]
+			uber_id = filtered_ref_file['uber_id'][i]
 
 			#If there are new matches, append all relevant columns to the matched_refs DataFrame
 			if title in clean_scraped_text:


### PR DESCRIPTION
Won't be available Monday morning so adding this now. Currently runs, but has a few bugs.

@nsorros, I've encountered a bug while adding rows to `matched_references` which seems to be caused by its duplicate columns name - three of the columns are called 'index'. I currently work around that by removing columns with duplicate names on line 60 of hard_text_search.py.
Do you know what the role if these multiple index columns is/is there any issue in removing them?