### PR TITLE
Fix build parse tests

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -64,14 +64,14 @@ class TestSplit(unittest.TestCase):
 	def test_split_by_question_mark(self):
 		self.assertEqual(
 			split_reference("To be? Or not to be?"),
-			["To be?", "Or not to be?"],
+			["To be", "Or not to be"],
 			"Should be a list with two elements"
 		)
 
 	def test_split_by_exclamation_mark(self):
 		self.assertEqual(
 			split_reference("To be! What a silly question"),
-			["To be!", "What a silly question"],
+			["To be", "What a silly question"],
 			"Should be a list with two elements"
 		)
 

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -14,7 +14,11 @@ def split_reference(reference):
         return []
 
     # To do: Check whether removing strip is having an impact
-    components = [elem.strip() for elem in re.split('[,?!.]', reference)]
+    components = [
+        elem.strip()
+        for elem in re.split('[,?!.]', reference)
+        if elem
+    ]
 
     return components
 


### PR DESCRIPTION
# Description

An build error was caused when we transition from
```
references = [
        reference.replace(
            "-\n", ""
        ).replace(
            "\n", " "
        ).replace(
            "â€™", "'"
        ).replace(
            "â€“", "-"
        )
        for reference in references
    ]
```
to 
```
    components = [
        elem.strip()
        for elem in re.split('[,?!.]', reference)
    ]
```

The main difference is that this new splitting does not contain the delimiter and adds empty components so we addressed both problems. The first by changing the tests since including the delimiter is of small importance to the tool at this point. The second by filtering empty components by adding an if to the list comprehension.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix 

# How Has This Been Tested?

`make docker-tests`


