### PR TITLE
Add references file to method4 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ If the `scraper_file`, `references_file`, `model_file`, arguments are to S3 loca
 If you would like to run the parser for the latest scraped files and to save the output locally, then run the following:
 ```
 python parse_latest.py msf \
---output-url "file://./tmp/parser-output"
+    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
+    --output-url "file://./tmp/parser-output"
 ```
 
 If you want to specify the arguments for the other inputs then you can, otherwise default values will be given:


### PR DESCRIPTION
At the moment, running parse latest according to method 4 throws an error if publications are not available in the default location which is not documented in the readme.

The location of the publication should be provided since the tool aims to serve an audience other than wellcome so this change introduces this parameter back in the readme and gives it the default s3 location so that in wellcome we can run parse latest regardless of local configurations, i.e. where wellcome publications are stored in our laptop