### PR TITLE
Remove default location for references file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ mkdir -p ./tmp/parser-output/output_folder_name
 
 python ./refparse.py \
     --scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
-    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
+    --references-file "file://./references_folder/references_file.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
     --output-url "file://./tmp/parser-output/output_folder_name"
 ```
@@ -73,7 +73,7 @@ If the `scraper_file`, `references_file`, `model_file`, arguments are to S3 loca
 The parsed and matched references from each documents are saved in a separate file in the output folder. You can merge all of them together by running
 ```
 python merge_results.py \
-    --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
+    --references-file "file://./references_folder/references_file.csv" \
     --output-url  "./tmp/parser-output/output_folder_name"
 ```
 

--- a/refparse.py
+++ b/refparse.py
@@ -280,11 +280,7 @@ def create_argparser(description):
     parser = ArgumentParser(description)
     parser.add_argument(
         '--references-file',
-        help='Path or S3 URL to references CSV file to match against',
-        default=os.path.join(
-            settings.REFERENCES_DIR,
-            settings.REFERENCES_FILENAME
-            )
+        help='Path or S3 URL to references CSV file to match against'
     )
 
     parser.add_argument(

--- a/settings.py
+++ b/settings.py
@@ -18,9 +18,6 @@ class BaseSettings:
     SCRAPER_RESULTS_DIR = "{}".format(SCRAPER_RESULTS_BASEDIR)
     SCRAPER_RESULTS_FILENAME = ''
 
-    REFERENCES_DIR = "s3://{}/wellcome_publications".format(BUCKET)
-    REFERENCES_FILENAME = 'uber_api_publications.csv'
-
     LOCAL_OUTPUT_DIR = 'local_output'
     PREF_REFS_FILENAME = 'predicted_reference_structures.csv'
     MATCHES_FILENAME = 'all_match_data.csv'
@@ -70,7 +67,6 @@ class LocalSettings(BaseSettings):
 
     SCRAPER_RESULTS_DIR = "scraper-results"
 
-    REFERENCES_DIR = "wellcome_publications"
     MODEL_DIR = "reference_parser_models"
 
     OUTPUT_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(


### PR DESCRIPTION
Fixes #81 

This could be controversial so I am happy to be rejected or altered according to your suggestions. Peter encountered a problem when running the policy tool which I had in the past as well which is that the default location for references is non present for a user and is also wellcome centric.

My opinion is that there should be no default as the publications are an input that the user provides. There should maybe a sample but every user can place their references in a different location and that is fine. This is different from the output which to a certain extent we can dictate where is placed and is also different for the scraped files since these, to a certain extent, are produced by our code. The references on the other hand are being brough by the user.

An alternative I am thinking is to create an empty folder in the repo for the user to place their publications there.

Any other thoughts, suggestions do let me know.