### PR TITLE
policytool: fix build with newer Debian & croniter

### DIFF
--- a/policytool/Dockerfile.base
+++ b/policytool/Dockerfile.base
@@ -1,5 +1,5 @@
-# Use a basic Python image
-FROM python:3.6.4
+# Use a basic Python image, but current Debian
+FROM python:3.6-slim-stretch
 
 # Build UTF8 locale to avoid encoding issues with Scrapy encoding
 # C.UTF-8 is the new en_US.UTF-8.

--- a/policytool/requirements.txt
+++ b/policytool/requirements.txt
@@ -41,7 +41,7 @@ cffi==1.12.1
 chardet==3.0.4
 colorama==0.4.1
 constantly==15.1.0
-croniter==0.3.27
+croniter==0.3.29
 cryptography==2.5
 cssselect==1.0.3
 defusedxml==0.5.0


### PR DESCRIPTION
# Description

We were using Debian jessie, which we can't trust anymore to have
packages listed. Also, croniter 0.3.27 is no longer present, per
similar failure found in datalabs/ repo.

Issue: https://github.com/wellcometrust/policytool/issues/115

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
make docker-test
```

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
