### PR TITLE
Add Elasticsearch to the localdev environment

### DIFF
--- a/policytool/docker-compose.yml
+++ b/policytool/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
-      - 9200:9200
+      - 127.0.0.1:9200:9200
 
   kibana:
     image: docker.elastic.co/kibana/kibana:7.0.0

--- a/policytool/docker-compose.yml
+++ b/policytool/docker-compose.yml
@@ -79,6 +79,22 @@ services:
     volumes:
       - ./build/airflow.redis:/data
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - 9200:9200
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.0.0
+    ports:
+      - 127.0.0.1:5601:5601
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+
   airflow-scheduler:
     image: *airflow-image
     environment:

--- a/policytool/elastic/import_from_s3.py
+++ b/policytool/elastic/import_from_s3.py
@@ -1,0 +1,119 @@
+""" Takes a given file size (default to 100MB) from a dataset in S3 and
+import them into a running Elasticsearch database.
+"""
+
+import tempfile
+import csv
+import json
+
+import boto3
+from urllib.parse import urlparse
+from argparse import ArgumentParser
+from elasticsearch import Elasticsearch
+
+parser = ArgumentParser()
+parser.add_argument('s3_url')
+
+parser.add_argument('-s', '--size',
+                    default=1024,
+                    type=int,
+                    help=('The megabytes to pull. Defaults to 100.'
+                          'A negative value will pull the entire dataset'))
+
+parser.add_argument('-H', '--host',
+                    default='127.0.0.1',
+                    help='Address of the Elasticsearch server')
+
+parser.add_argument('-P', '--port',
+                    default='9200',
+                    help='Port of the Elasticsearch server')
+
+parser.add_argument('-C', '--clean', dest='clean', action='store_true',
+                    help='Clean the elasticsearch database before import')
+
+
+def write_to_es(es, line):
+    """ Writes the given csv line to elasticsearch.
+
+    Args:
+        es: a living connection to elacticsearch
+        line: a dict from a csv line. Should contain a file hash and the
+              full text of a pdf
+    """
+    body = json.dumps({
+        'hash': line['file_hash'],
+        'text': line['pdf_text']
+    })
+    es.index(
+        index='datalabs-fulltexts',
+        ignore=400,
+        body=body,
+        doc_type='pdf_fulltext'
+    )
+
+
+def clean_es(es):
+    """ Empty the elasticsearch database.
+
+    Args:
+        es: a living connection to elasticsearch
+
+    """
+    print('Cleaning te database..')
+    body = json.dumps({
+        'query': {
+            'match_all': {}
+        }
+    })
+    es.delete_by_query(
+        index='datalabs-fulltexts',
+        body=body,
+    )
+
+
+def import_data(s3_file, es, size):
+    """ Import data from a given file in elasticsearch.
+
+    Args:
+        s3_file: a file object from boto3's s3
+        es: a living connection to elasticsearch
+        size: the size of the data to pull in bytes
+
+    """
+    with tempfile.TemporaryFile(mode='r+b') as tf:
+        rows = s3_file.get(Range='bytes=0-%d' % size)
+        for data in rows['Body']:
+            tf.write(data)
+
+        print('Got the fileobj')
+        tf.seek(0)
+        with open(tf.fileno(), mode='r', closefd=False) as csv_file:
+            for line in csv.DictReader(csv_file):
+                print(line['file_hash'])
+                write_to_es(es, line)
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    assert args.s3_url.startswith('s3://'), (
+            "You must provide a valid s3:// link"
+        )
+
+    es = Elasticsearch([{'host': args.host, 'port': args.port}])
+    s3 = boto3.resource('s3')
+
+    parsed_url = urlparse(args.s3_url)
+    print('Getting %s from %s bucket' % (parsed_url.path, parsed_url.netloc))
+    s3_file = s3.Object(bucket_name=parsed_url.netloc, key=parsed_url.path[1:])
+
+    # This is a big file. The size should be in megabytes, not in bytes
+    size = args.size * 1000 ** 2
+
+    # Full texts are big, so get rid of python limitation for csv field size
+    csv.field_size_limit(1000000)
+
+    if args.clean:
+        clean_es(es)
+
+    import_data(s3_file, es, size)

--- a/policytool/requirements.txt
+++ b/policytool/requirements.txt
@@ -26,6 +26,7 @@ cssselect==1.0.3
 defusedxml==0.5.0
 dill==0.2.9
 docutils==0.14
+elasticsearch>=7.0.0,<8.0.0
 enum34==1.1.6
 Flask==1.0.2
 Flask-Admin==1.5.3


### PR DESCRIPTION
# Description

Brings Elasticsearch as a search service to our localdev environment. Also brings a Kibana instance to investigate the data.

This PR also adds a script to pull data from a full text dataset in s3.

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

Local tests, MacOs 10.14.4, Python 3.6.4, Docker@2Cpu/4GbRam