### PR TITLE
Add a search tool to the web API

### DIFF
--- a/policytool/docker-compose.yml
+++ b/policytool/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
       - 127.0.0.1:9200:9200
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
 
   kibana:
     image: docker.elastic.co/kibana/kibana:7.0.0
@@ -150,8 +152,8 @@ services:
       AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
       SENTRY_DSN: "${SENTRY_DSN}"
-
       STATIC_ROOT: /src/policytool/web/build/static
+      ELASTICSEARCH_HOST: "http://elasticsearch:9200"
       # DATABASE_URL: "postgres://postgres:postgres@articles-db:5432/wsf_scraping"
 
     command:
@@ -177,3 +179,7 @@ services:
       - ./web/static:/src/static
     # Signal handling in gulp? Not so much...
     stop_signal: SIGKILL
+
+volumes:
+    esdata:
+        driver: local

--- a/policytool/elastic/import_from_s3.py
+++ b/policytool/elastic/import_from_s3.py
@@ -5,6 +5,7 @@ import them into a running Elasticsearch database.
 import tempfile
 import csv
 import json
+import random
 
 import boto3
 from urllib.parse import urlparse
@@ -40,9 +41,15 @@ def write_to_es(es, line):
         line: a dict from a csv line. Should contain a file hash and the
               full text of a pdf
     """
+    # TODO: Use real pdf titles and orgs
+    # Select a random org for the time being
+    orgs = ['who', 'nice', 'msf']
+    org = random.choice(orgs)
     body = json.dumps({
         'hash': line['file_hash'],
-        'text': line['pdf_text']
+        'text': line['pdf_text'],
+        'title': line['pdf_name'],
+        'organisation': org,
     })
     es.index(
         index='datalabs-fulltexts',

--- a/policytool/web/api.py
+++ b/policytool/web/api.py
@@ -8,14 +8,13 @@ Entrypoint for web UI & API. Run with:
 import logging
 import os
 import os.path
+from urllib.parse import urlparse
 
 import falcon
 import jinja2
-
-from urllib.parse import urlparse
 from elasticsearch import Elasticsearch
 
-from web import search
+from . import search
 
 TEMPLATE_ROOT = os.path.join(os.path.dirname(__file__), 'templates')
 STATIC_ROOT = os.environ.get('STATIC_ROOT')
@@ -117,18 +116,14 @@ configure_logger(logger)
 assert os.environ.get('ELASTICSEARCH_HOST'), 'No elasticsearch host'
 parsed_url = urlparse(os.environ['ELASTICSEARCH_HOST'])
 
-try:
-    logger.info('Trying to connect to {elastic_host}'.format(
-        elastic_host=os.environ['ELASTICSEARCH_HOST']
-    ))
-    es = Elasticsearch([{
-            'host': parsed_url.hostname,
-            'port': parsed_url.port
-        }],
-    )
-except Exception as e:
-    raise e
-
+logger.info('Connecting to {elastic_host}'.format(
+    elastic_host=os.environ['ELASTICSEARCH_HOST']
+))
+es = Elasticsearch([{
+        'host': parsed_url.hostname,
+        'port': parsed_url.port
+    }],
+)
 
 # Routes (are LIFO)
 api = falcon.API()

--- a/policytool/web/api.py
+++ b/policytool/web/api.py
@@ -80,6 +80,14 @@ def get_context(os_environ):
     }
 
 
+class Configuration:
+    def __init__(self):
+        # Elasticsearch stuff
+        assert os.environ.get('ELASTICSEARCH_HOST'), 'No elasticsearch host'
+        self.es_host = os.environ['ELASTICSEARCH_HOST']
+        self.es_explain = os.environ.get('ELASTICSEARCH_EXPLAIN', False)
+
+
 class TemplateResource:
     """
     Serves HTML templates. Note that templates are read from the FS for
@@ -112,12 +120,11 @@ class TemplateResource:
 logger = logging.getLogger()
 configure_logger(logger)
 
-# Elasticsearch stuff
-assert os.environ.get('ELASTICSEARCH_HOST'), 'No elasticsearch host'
-parsed_url = urlparse(os.environ['ELASTICSEARCH_HOST'])
+conf = Configuration()
+parsed_url = urlparse(conf.es_host)
 
 logger.info('Connecting to {elastic_host}'.format(
-    elastic_host=os.environ['ELASTICSEARCH_HOST']
+    elastic_host=conf.es_host
 ))
 es = Elasticsearch([{
         'host': parsed_url.hostname,
@@ -133,6 +140,6 @@ api.add_route(
 )
 api.add_route(
     '/search',
-    search.Fulltext(es)
+    search.Fulltext(es, conf.es_explain)
 )
 api.add_static_route('/static', STATIC_ROOT)

--- a/policytool/web/search.py
+++ b/policytool/web/search.py
@@ -54,14 +54,14 @@ class Fulltext(object):
         except ConnectionError:
             message = 'Could not join the elasticsearch server'
             api.logger.error(message)
-            return False, message
+            raise falcon.HTTPServiceUnavailable(description=message)
 
         except NotFoundError:
             message = 'No results found.'
             return False, message
 
         except Exception as e:
-            return False, str(e)
+            raise falcon.HTTPError(description=str(e))
 
     def on_get(self, req, resp):
         """Returns the result of a search on the elasticsearch cluster.
@@ -73,14 +73,13 @@ class Fulltext(object):
         if req.params:
             status, response = self._search_es(req.params)
             if status:
+                response['status'] = 'success'
                 resp.body = json.dumps(response)
             else:
                 resp.body = json.dumps({
                     'status': 'error',
                     'message': response
                 })
-
-                resp.status = falcon.HTTP_500
         else:
             resp.body = json.dumps({
                 'status': 'error',

--- a/policytool/web/search.py
+++ b/policytool/web/search.py
@@ -16,7 +16,7 @@ class Fulltext(object):
     def __init__(self, es):
         self.es = es
 
-    def search_es(self, req_params):
+    def _search_es(self, req_params):
         """Run a search on the elasticsearch database.
 
         Args:
@@ -71,7 +71,7 @@ class Fulltext(object):
             resp: The reponse object to be returned
         """
         if req.params:
-            status, response = self.search_es(req.params)
+            status, response = self._search_es(req.params)
             if status:
                 resp.body = json.dumps(response)
             else:
@@ -79,8 +79,11 @@ class Fulltext(object):
                     'status': 'error',
                     'message': response
                 })
+
+                resp.status = falcon.HTTP_500
         else:
             resp.body = json.dumps({
-                'status': 'error'
+                'status': 'error',
+                'message': "The request doesn't contain any parameters"
             })
-            resp.status = falcon.HTTP_200
+            resp.status = falcon.HTTP_400

--- a/policytool/web/search.py
+++ b/policytool/web/search.py
@@ -13,8 +13,9 @@ class Fulltext(object):
         es: An elasticsearch connection
     """
 
-    def __init__(self, es):
+    def __init__(self, es, es_explain):
         self.es = es
+        self.es_explain = es_explain
 
     def _search_es(self, req_params):
         """Run a search on the elasticsearch database.
@@ -48,7 +49,7 @@ class Fulltext(object):
             return True, self.es.search(
                 index='datalabs-fulltexts',
                 body=json.dumps(es_body),
-                explain=True
+                explain=self.es_explain
             )
 
         except ConnectionError:
@@ -61,6 +62,7 @@ class Fulltext(object):
             return False, message
 
         except Exception as e:
+            api.logger.error(e)
             raise falcon.HTTPError(description=str(e))
 
     def on_get(self, req, resp):

--- a/policytool/web/search.py
+++ b/policytool/web/search.py
@@ -1,0 +1,86 @@
+import json
+
+import falcon
+
+from elasticsearch import ConnectionError, NotFoundError
+from web import api
+
+
+class Fulltext(object):
+    """Let you search for terms in publications fulltexts.
+
+    Args:
+        es: An elasticsearch connection
+    """
+
+    def __init__(self, es):
+        self.es = es
+
+    def search_es(self, req_params):
+        """Run a search on the elasticsearch database.
+
+        Args:
+            req_params: The request's parameters. Shoud include 'term' and at
+                        least a field (on of [text|title|organisation])
+
+        Returns:
+            True|False: The search success status
+            es.search()|str: A dict containing the result of the search if it
+                             succeeded or a string explaining why it failed
+        """
+        try:
+            fields = req_params.get('fields', [])
+            self.es.cluster.health(wait_for_status='yellow')
+
+            es_body = {
+                'query': {
+                    'multi_match': {
+                        'query': req_params.get('term'),
+                        'fields': fields
+                    }
+                }
+            }
+
+            api.logger.info('Searching for "{query}"'.format(
+                query=es_body
+            ))
+
+            return True, self.es.search(
+                index='datalabs-fulltexts',
+                body=json.dumps(es_body),
+                explain=True
+            )
+
+        except ConnectionError:
+            message = 'Could not join the elasticsearch server'
+            api.logger.error(message)
+            return False, message
+
+        except NotFoundError:
+            message = 'No results found.'
+            return False, message
+
+        except Exception as e:
+            return False, str(e)
+
+    def on_get(self, req, resp):
+        """Returns the result of a search on the elasticsearch cluster.
+
+        Args:
+            req: The request passed to this controller
+            resp: The reponse object to be returned
+        """
+        if req.params:
+            status, response = self.search_es(req.params)
+            if status:
+                resp.body = json.dumps(response)
+            else:
+                resp.body = json.dumps({
+                    'status': 'error',
+                    'message': response
+                })
+        else:
+            resp.body = json.dumps({
+                'status': 'error'
+            })
+            resp.status = falcon.HTTP_200


### PR DESCRIPTION
# Description

This PR brings a search route to the API.

 - Define the route in api.py
 - Define the service in search.py
 - Change elastic/import_to_s3.py to also insert pdf_names and (randomly assigned for the time being) organisations
 - Add a persistent volume to the elasticsearch container

## Type of change
- [x] :sparkles: New feature

# How Has This Been Tested?

Mac OSx 10.14.4, Python3.6.4, Docker 18.09.5 with 2CPU/4Gb RAM
