### PR TITLE
Makefile: set execution bit for docker_run.sh b/c CodePipeline

### DIFF
--- a/policytool/Makefile
+++ b/policytool/Makefile
@@ -37,6 +37,10 @@ web-build-image:
 # a phony target. Not great but we don't need incremental builds
 # for static web sources.
 $(WEB_BUILD_TARGETS): web-build-image $(WEB_BUILD_SOURCES)
+	@# CodePipeline (but not CodeBuild) code checkouts lose execution bits
+	@# (https://forums.aws.amazon.com/thread.jspa?threadID=235452).
+	@# So, fix this for CI builds.
+	@chmod +x web/bin/docker_run.sh
 	web/bin/docker_run.sh gulp default
 
 .PHONY: docker-build


### PR DESCRIPTION
# Description

As noted in the comments, fix CodePipeline's breaking our permissions,
and thus breaking our build.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
