### PR TITLE
Allow initdb execution from the kubernetes cluster instance

### DIFF
--- a/policytool/Dockerfile
+++ b/policytool/Dockerfile
@@ -21,6 +21,7 @@ COPY scraper/airflow/airflow.cfg /airflow/
 COPY scraper/airflow/initdb.sh /airflow/
 RUN mkdir -p /airflow/db && \
     ln -s /src/policytool/scraper/airflow/dags /airflow/dags && \
+    chmod +x /airflow/initdb.sh && \
     chown -R www-data: /airflow
 
 


### PR DESCRIPTION
# Description

On kubernetes, airflow first runs the `/airflow/initdb.sh` command. This command requires the execution privilege on the initdb file.

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

Mac OSx 10.14.4, Python3.6.4, Docker 18.09.5 with 2CPU/4Gb RAM
