### PR TITLE
Fix input and output of fuzzy match

### DIFF
--- a/policytool/refparse/utils/fuzzymatch.py
+++ b/policytool/refparse/utils/fuzzymatch.py
@@ -51,6 +51,18 @@ class FuzzyMatcher:
                 for i,row in enumerate(title_similarities)\
                 if row[np.argmax(row)]>self.threshold
                ]
+
+        if above_threshold_indices_pairs == []:
+            return pd.DataFrame({
+                'Document id': [],
+                'Reference id': [],
+                'Title': [],
+                'title': [],
+                'uber_id': [],
+                'Cosine_Similarity': [],
+                'Match_algorithm': "Fuzzy Matcher"
+            })
+
         # Restructure indices into 
         # [array([0, 1, 2, ... , 398]), array([77523, 5258, 66691, ... 94142])]
         above_threshold_indices = (

--- a/policytool/refparse/utils/fuzzymatch.py
+++ b/policytool/refparse/utils/fuzzymatch.py
@@ -46,13 +46,13 @@ class FuzzyMatcher:
 
         # Get indices of highest cosine similarity over threshold for each predicted publication row
         # In form [(0, 77523), (1, 5258), (2, 66691) ..., (398, 94142)]]
-        above_threshold_indices_pairs = [
+        max_above_threshold_indices_pairs = [
                 (i,np.argmax(row))\
                 for i,row in enumerate(title_similarities)\
                 if row[np.argmax(row)]>self.threshold
                ]
 
-        if above_threshold_indices_pairs == []:
+        if max_above_threshold_indices_pairs == []:
             return pd.DataFrame({
                 'Document id': [],
                 'Reference id': [],
@@ -65,16 +65,16 @@ class FuzzyMatcher:
 
         # Restructure indices into 
         # [array([0, 1, 2, ... , 398]), array([77523, 5258, 66691, ... 94142])]
-        above_threshold_indices = (
-            np.asarray([a for a, b in above_threshold_indices_pairs]),
-            np.asarray([b for a, b in above_threshold_indices_pairs])
+        max_above_threshold_indices = (
+            np.asarray([a for a, b in max_above_threshold_indices_pairs]),
+            np.asarray([b for a, b in max_above_threshold_indices_pairs])
             )
 
         cosine_similarities = title_similarities[
-            above_threshold_indices
+            max_above_threshold_indices
         ]
 
-        predicted_indices, real_indices = above_threshold_indices
+        predicted_indices, real_indices = max_above_threshold_indices
 
         match_data = pd.concat([
             predicted_publications.iloc[predicted_indices][[


### PR DESCRIPTION
Rewrite `fuzzymatch.py` to allow single row inputs and to output only one match with the highest cosine similarity over the threshold per publication, previously it would return everything over the threshold

Fix issue https://github.com/wellcometrust/policytool/issues/139

Fix issue https://github.com/wellcometrust/policytool/issues/138

# Description

`fuzzymatch.py` would throw up an error if you tried to only match one publication (arguably this might not happen in practise though), see issue https://github.com/wellcometrust/policytool/issues/138.
This has been fixed.

It also used to output every single match over a threshold for a document, but this should have been just the best match per document. See issue https://github.com/wellcometrust/policytool/issues/139.
This has been fixed.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

Yes, unittests completes.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
