### PR TITLE
Add evaluate split section metric

### DIFF
--- a/policytool/refparse/algo_evaluation/evaluate_split_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_split_section.py
@@ -1,9 +1,68 @@
-import pandas as pd
+import pandas as pd 
+import numpy as np
 from utils.split import split_section
 
-def evaluate_metric(actual, predicted):
+def calc_num_metric(predicted_number, actual_number):
+    """
+    How similar are 2 numbers of references?
+    The difference between the predicted and actual numbers of references
+    as a percentage of the actual number
+    """
 
-    test_scores = {'Score' : 50, 'More info' : "More information about this test"}
+    # In the case of 0 references (some documents don't have references but do
+    # have a reference section), set actual_number to the closest integer, 1.
+    # This introduces some small error, but avoids the script throwing a math error
+    if actual_number == 0:
+        actual_number = 1
+
+    metric = abs(100*((predicted_number - actual_number) / actual_number))
+
+    return metric
+
+def evaluate_splitter_nums(number_predicted_references, number_actual_references, threshold):
+    """
+    Calculates the number of references test metric for each document.
+    Input:
+        number_predicted_references : A list of the predicted numbers
+                                        of references from a sample of documents
+        number_actual_references : A list of the actual numbers
+                                        of references from a sample of documents
+        threshold : a threshold for the percentage difference acceptable to be below
+    Output:
+        median_diff : the median percentage difference for a sample of documents
+        below_threshold : the percentage of documents with a test metric less than the threshold
+    """
+   
+    doc_metrics = [calc_num_metric(m,n) for m,n in zip(number_predicted_references, number_actual_references)]
+
+    median_diff = round(np.median(doc_metrics), 1)
+    below_threshold = round(
+        100 * len([x for x in doc_metrics if x <= threshold]) / len(doc_metrics),
+        1
+    )
+
+    return doc_metrics, median_diff, below_threshold
+
+def evaluate_metric(actual, predicted, sources, threshold):
+
+    doc_metrics, median_diff, below_threshold = evaluate_splitter_nums(predicted, actual, threshold)
+
+    source_metric = pd.DataFrame(
+        [list(sources), doc_metrics]
+        ).transpose().rename(columns = {0 : "Source", 1 : "Metric"})
+
+    aggregations = {
+            'Median difference' : lambda x : round(np.median(x), 1),
+            'Percentage below threshold of {}'.format(threshold) : lambda x : round(100 * len([y for y in x if y <= threshold]) / len(x),1)
+    }
+    grouped_source_metrics = source_metric.groupby('Source')['Metric'].agg(aggregations)
+
+    test_scores = {
+        'Score' : below_threshold,
+        'Percentage below threshold of {}'.format(threshold) : below_threshold,
+        'Median difference' : median_diff,
+        'Metrics grouped by source' : grouped_source_metrics
+        }
 
     return test_scores
 
@@ -13,19 +72,17 @@ def evaluate_split_section(split_section_test_data, regex, threshold):
     and compare the findings with the ground truth
     """
 
-    comparison = []
+    evaluation_info = []
     for references_section in split_section_test_data['Reference section']:
         references = split_section(references_section, regex = regex)
-
-        comparison.append(
+        evaluation_info.append(
             {
             "Predicted references" : references,
             "Predicted number of references" : len(references)
             }
             )
-    comparison = pd.concat([split_section_test_data, pd.DataFrame(comparison)], axis = 1)
+    evaluation_info = pd.concat([split_section_test_data, pd.DataFrame(evaluation_info)], axis = 1)
 
-    test_info = comparison
-    test_scores = evaluate_metric(comparison["Number of references scraped"], comparison["Predicted number of references"])
+    test_scores = evaluate_metric(evaluation_info["Number of references scraped"], evaluation_info["Predicted number of references"], evaluation_info["Source"], threshold)
 
-    return test_scores 
+    return test_scores

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -30,7 +30,7 @@ def create_argparser():
     parser.add_argument(
         '--verbose',
         help='Whether you want to print detailed test information ("True") or not ("False")',
-        default = False
+        default = True
     )
 
     return parser
@@ -39,8 +39,6 @@ if __name__ == '__main__':
 
     parser = create_argparser()
     args = parser.parse_args()
-
-    verbose='FALSE'
 
     now = datetime.now()
     logger = settings.logger
@@ -129,10 +127,10 @@ if __name__ == '__main__':
     test5_scores = evaluate_match_references(match_publications, test_publications, settings.FUZZYMATCH_THRESHOLD)
 
     test_scores_list = [test1_scores, test2_scores, test3_scores, test4_scores, test5_scores]
-    if args.verbose == 'True':
+    if args.verbose:
         for i, tests in enumerate(test_scores_list):
-            log_file.write("\nInformation about test {}:\n".format(i))
-            log_file.write(tests)
+            log_file.write("\n-----Information about test {}:-----\n".format(i))
+            [log_file.write("\n"+k+"\n"+str(v)+"\n") for (k,v) in tests.items()]
     else:
         for i, tests in enumerate(test_scores_list):
             log_file.write("\nScore for test {}:\n".format(i))


### PR DESCRIPTION
Add metric calculation for evaluate split section and make the print out in a nice format

Note that the new functions are largely copied and pasted from [here](https://github.com/wellcometrust/datalabs/blob/bced9699254199ecff76edeca1ce80cefbaa9a01/modelling/policy/references-splitting/src/evaluate_splitter.py) (where `calc_num_metric` and `evaluate_splitter_nums` are practically the same - I return an extra variable in the latter)

# Description

This PR adds some functions to `evaluate_split_section.py` to calculate this evaluation metric.
I also edit the log file print in `evaluate_algo.py` so that it prints the information in a nice format, which now looks like:

```
-----Information about test 2:-----

Score
52.8

Percentage below threshold of 40
52.8

Median difference
29.6

Metrics grouped by source
          Median difference  Percentage below threshold of 40
Source                                                       
msf                     7.3                              83.3
nice                   95.8                               0.0
unicef                 27.4                              90.0
who_iris               10.0                              82.4
```

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [x] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

No tests.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
