### PR TITLE
Add evaluate match refs metric

### DIFF
--- a/docs/evaluation_data.md
+++ b/docs/evaluation_data.md
@@ -18,4 +18,6 @@ In this document we describe how we got each of the evaluation datasets uses in 
 "./algo_evaluation/data_evaluate/positive_and_negative_match_test_data.csv"
 "./algo_evaluation/data_evaluate/uber_api_publications.csv"
 
+We randomly selected 200 references from a list of Wellcome Trust publications from Uber Dimensions ("uber_api_publications.csv"). With this list (the 'positive' list) we used the fuzzy match algorithm to find a list (the 'negative' list) of the second most similar references to them (i.e. the best match would be the reference in question, and the second would be quite similar). The positive list was reduced to 199 since one reference didn't have a second strong match, and the negative list gave 202 references since for some references there were multiple references with the same cosine similarity competing for second place. In the match evaluation we match both the positive and negative lists against a copy of "uber_api_publications.csv" but with the negative list of references removed. Thus, if our matching is working perfectly the references in the positive list should all be matched and the references in the negative list should not be matched.
+
 

--- a/policytool/refparse/algo_evaluation/evaluate_match_references.py
+++ b/policytool/refparse/algo_evaluation/evaluate_match_references.py
@@ -6,43 +6,48 @@ from utils import FuzzyMatcher
 
 def evaluate_metric(actual, predicted):
 
-    similarity = round(f1_score(actual, predicted, average='micro'), 3)
+    actual_binary = actual.astype(int)
+    # predicted is True, False and "No match found",
+    # convert to 1 (True) or 0 (False or "No match found")
+    predicted_binary = [1 if pred_type==True else 0 for pred_type in predicted]
+
+    similarity = round(f1_score(actual_binary, predicted_binary, average='micro'), 3)
 
     test_scores = {
         'Score' : similarity,
         'Micro average F1-score' : similarity,
-        'Classification report' : classification_report(actual, predicted) 
+        'Classification report' : classification_report(actual_binary, predicted_binary),
+        'Frequency table of match types' : pd.crosstab(index=actual, columns=predicted) 
         }
 
     return test_scores
 
-def evaluate_match_references(match_publications, test_publications, match_threshold):
+def evaluate_match_references(publications, evaluation_references, match_threshold):
+    """
+    Try to match the evaluation_references with references in 'publications'
+    """
 
     # Get the data into the same format as would be
-    test_publications = test_publications.rename(columns={'Match title': 'Title', 'Match pub id': 'Reference id'})
-    test_publications['Journal'] = None
-    test_publications['PubYear'] = None
-    test_publications['Authors'] = None
-    test_publications['Issue'] = None
-    test_publications['Volume'] = None
-    test_publications['Document id'] = range(0, len(test_publications))
-    test_publications['Document uri'] = None
+    evaluation_references = evaluation_references.rename(columns={'Match title': 'Title', 'Match pub id': 'Reference id'})
+    evaluation_references['Document id'] = range(0, len(evaluation_references))
 
     # Take out the negative reference id's (so you shouldn't find them)
-    neg_test_pub_ids = test_publications.loc[test_publications['Type']==0]['Reference id']
-    match_publications_no_negs = match_publications.loc[~match_publications['uber_id'].isin(neg_test_pub_ids)]
+    neg_test_pub_ids = evaluation_references.loc[evaluation_references['Do we expect a match?']==0]['Reference id']
+    publications_no_negs = publications.loc[~publications['uber_id'].isin(neg_test_pub_ids)]
 
-    fuzzy_matcher = FuzzyMatcher(match_publications_no_negs, match_threshold)
+    fuzzy_matcher = FuzzyMatcher(publications_no_negs, match_threshold)
 
-    match_data = fuzzy_matcher.match_vectorised(test_publications)
+    matched_publications = fuzzy_matcher.match_vectorised(evaluation_references)
 
-    # Does each publication have the correct match (True) or not (False)
-    # (There might not be matches found for all the test_publications)
-    merged_test_pred = pd.merge(test_publications, match_data, how="left", left_on='Reference id', right_on='Reference id')
-    match_correct = merged_test_pred['Reference id']==merged_test_pred['uber_id']
+    evaluation_matches = pd.merge(evaluation_references, matched_publications, how="left", left_on='Reference id', right_on='Reference id')
 
-    merged_test_pred['Matched correctly?'] = match_correct
+    # Does each publication have the correct match (true), an incorrect match (false) or no match
+    evaluation_matches['Matched correctly?'] = [
+        matches['Reference id']==matches['uber_id'] if not pd.isnull(matches['uber_id'])\
+        else "No match found"\
+        for _, matches in evaluation_matches.iterrows()
+        ]
 
-    test_scores = evaluate_metric(merged_test_pred['Type'].astype(int), merged_test_pred['Matched correctly?'].astype(int))
+    test_scores = evaluate_metric(evaluation_matches['Do we expect a match?'], evaluation_matches['Matched correctly?'])
 
     return test_scores

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     # Load data to test matching for test 5:
     logger.info('[+] Reading {}'.format(settings.TEST_PUB_DATA_FILE_NAME))
-    test_publications = fm.get_file(
+    evaluation_references = fm.get_file(
         settings.TEST_PUB_DATA_FILE_NAME,
         settings.FOLDER_PREFIX,
         'csv'
@@ -99,7 +99,7 @@ if __name__ == '__main__':
 
     # Load WT publications to match references against
     logger.info('[+] Reading {}'.format(settings.MATCH_PUB_DATA_FILE_NAME))
-    match_publications = fm.get_file(
+    publications = fm.get_file(
         settings.MATCH_PUB_DATA_FILE_NAME,
         settings.FOLDER_PREFIX,
         'csv'
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     test4_scores = evaluate_parse(parse_test_data, model)
 
     logger.info('[+] Running test 5')
-    test5_scores = evaluate_match_references(match_publications, test_publications, settings.FUZZYMATCH_THRESHOLD)
+    test5_scores = evaluate_match_references(publications, evaluation_references, settings.FUZZYMATCH_THRESHOLD)
 
     test_scores_list = [test1_scores, test2_scores, test3_scores, test4_scores, test5_scores]
     if args.verbose:


### PR DESCRIPTION
# Description
Similarly to the other PRs, adding the metric to `evaluate_match_references.py`. 

Since we fixed the issue of the fuzzy matcher returning multiple matches, some of `evaluate_match_references` was unnecessarily complicated for the new output of match_vectorised, so I rewrote some of it.

I was also not taking away the negative examples from the match data, so i fixed this.

Also added some info about how we got the evaluation data to the document.

The output of this test is v good, as we might expect:

```
Score
0.998

Micro average F1-score
0.998

Classification report
              precision    recall  f1-score   support

           0       1.00      1.00      1.00       202
           1       1.00      0.99      1.00       199

   micro avg       1.00      1.00      1.00       401
   macro avg       1.00      1.00      1.00       401
weighted avg       1.00      1.00      1.00       401

```
## Type of change

- [ ] :sparkles: New feature

# How Has This Been Tested?

No tests.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
