### PR TITLE
Update merge results to return predicted references

### DIFF
--- a/policytool/refparse/merge_results.py
+++ b/policytool/refparse/merge_results.py
@@ -64,7 +64,6 @@ def concat_predicted_csvs(predicted_csv_names):
         all_url - a dataframe containing document id and document url
     """
     all_predicted_references = []
-    all_url = []
     for predicted_csv_name in predicted_csv_names:
         # Some (4) of the files don't read in without errors
         try:
@@ -73,11 +72,10 @@ def concat_predicted_csvs(predicted_csv_names):
             print('Read csv issue for file {}'.format(predicted_csv_name))
         if not pred_data.empty:
             all_predicted_references.append(pred_data)
-            # Each row has the same doc id and doc url, so only need to use first row
-            all_url.append({'Document id' : pred_data.iloc[0]['Document id'],
-                'Document uri' : pred_data.iloc[0]['Document uri']})
 
-    all_url = pd.DataFrame.from_dict(all_url)
+    all_url = all_predicted_references[
+        ['Document id', 'Document uri']
+    ].drop_duplicates()
     all_predicted_references = pd.concat(all_predicted_references)
     return all_url, all_predicted_references
 

--- a/policytool/refparse/merge_results.py
+++ b/policytool/refparse/merge_results.py
@@ -43,7 +43,6 @@ def concat_match_csvs(match_csv_names):
         try:
             match_data = pd.read_csv(match_csv_name)
         except:
-            print(match_csv_name)
             continue
         if not match_data.empty:
             all_matches.append(match_data)


### PR DESCRIPTION
# Description

This PR adds functionality for merge_results to return the predicted references as well as the matches which is the other half of the output of the policy tool. This became necessary after realizing that the database is not maintained and it is a better idea to rely on runs of the policy tool for getting the latest numbers than querying the database.

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
