### PR TITLE
Add evaluate scraper metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ This will test that your last changes didn't affect how the program works.
 
 ## Evaluating each component of the algorithm
 
-We have devised some evaluation data in order to evaluate 5 steps of the model. The results can be found by first downloading the evaluation data from [here](https://s3-eu-west-1.amazonaws.com/datalabs-data/policy_tool_tests), and then running
+We have devised some evaluation data in order to evaluate 5 steps of the model. The results can be found by first installing poppler
+```
+brew install poppler
+```
+and then downloading the evaluation data from [here](https://s3-eu-west-1.amazonaws.com/datalabs-data/policy_tool_tests), and then running
 ```
 python evaluate_algo.py --verbose True
 ```

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This will test that your last changes didn't affect how the program works.
 
 ## Evaluating each component of the algorithm
 
-We have devised some evaluation data in order to evaluate 5 steps of the model. The results can be found by first installing poppler
+We have devised some evaluation data in order to evaluate 5 steps of the model. The results can be calculated by first installing poppler
 ```
 brew install poppler
 ```

--- a/docs/evaluation_data.md
+++ b/docs/evaluation_data.md
@@ -2,7 +2,11 @@ In this document we describe how we got each of the evaluation datasets uses in 
 
 ## Scrape Evaluation
 
-"./algo_evaluation/data_evaluate/scrape_test_data.csv"
+- We generated a random list of policy documents we currently scrape from various policy organisations.
+- We went through this list until we found X which had a section that contain references and X that didn't.
+- The pdfs for these were saved in "./algo_evaluation/data_evaluate/pdfs", named with a unique identifier for this pdf.
+- We looked for the text from sections Reach currently looks for in the pdfs ('reference' and 'bibliograph')
+- The text was copied and pasted from the pdf into a markdown file and saved as a .txt file in the relevant sections folder (e.g. "./algo_evaluation/data_evaluate/pdf_sections/reference") and saved with the same unique name as the pdf was.
 
 ## Split Section Evaluation
 

--- a/policytool/pdf_parser/main.py
+++ b/policytool/pdf_parser/main.py
@@ -9,7 +9,7 @@ import logging
 import tempfile
 import json
 
-from scraper.scraper.file_system import S3FileSystem, LocalFileSystem
+from scraper.wsf_scraping.file_system import S3FileSystem, LocalFileSystem
 from pdf_parser.pdf_parse import parse_pdf_document, grab_section
 
 logger = logging.getLogger(__name__)

--- a/policytool/refparse/algo_evaluation/evaluate_find_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_find_section.py
@@ -34,20 +34,23 @@ def evaluate_metric_scraped(actual, predicted, sections):
 
     test_scores = {
         'Score' : similarity,
-        'Micro average F1-score' : similarity,
+        'F1-score' : similarity,
         'Classification report' : classification_report(actual, predicted),
         'Confusion matrix' : pretty_confusion_matrix(
                 actual, predicted, [True, False]
             )
         }
 
+    sections_texts = pd.DataFrame(
+        {'Section': sections, 'Actual': actual, 'Predicted': predicted}
+        )
+
     for section_name in set(sections):
-        actual_section = [
-            a for (s,a) in zip(sections, actual) if s == section_name
-        ]
-        predicted_section = [
-            p for (s,p) in zip(sections, predicted) if s == section_name
-        ]
+        section_text = sections_texts[sections_texts['Section']==section_name]
+
+        actual_section = section_text['Actual']
+        predicted_section = section_text['Predicted']
+
         test_scores["Classification report for the {} section".format(
             section_name
             )] = classification_report(actual_section, predicted_section)

--- a/policytool/refparse/algo_evaluation/evaluate_find_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_find_section.py
@@ -1,48 +1,138 @@
+import sys
+sys.path.append("..")
+from pdf_parser.pdf_parse import parse_pdf_document, grab_section
 
-def evaluate_metric_scraped(actual, predicted):
+import os.path
+import pandas as pd
+import numpy as np
+
+from sklearn.metrics import classification_report, f1_score
+import editdistance
+
+def evaluate_metric_scraped(actual, predicted, section_names):
     """
-    False positive rate
+    Input:
+        actual : a boolean list of whether section text was in the pdf
+        predicted : a boolean list of whether section text was scraped
+        section_names : a list of the section names
     """
-    # Place holder
-    test_scores = {'Score' : 50, 'More info' : "More information about this test"}
+
+    similarity = round(f1_score(actual, predicted, average='micro'), 3)
+
+    test_scores = {
+        'Score' : similarity,
+        'Micro average F1-score' : similarity,
+        'Classification report' : classification_report(actual, predicted) 
+        }
+
+    for section_name in set(section_names):
+        has_section = [e for i,e in enumerate(actual) if section_names[i] == section_name]
+        has_scraped_section = [e for i,e in enumerate(predicted) if section_names[i] == section_name]
+        test_scores["Classification report for the {} section".format(section_name)] = classification_report(has_section, has_scraped_section)
 
     return test_scores
 
 
-def evaluate_metric_quality(actual, predicted):
+def evaluate_metric_quality(actual, predicted, sections, levenshtein_threshold):
     """
-    Text similarity
+    Text similarity for when there is a section (actual!='')
     """
-    test_scores = {'Score' : 50, 'More info' : "More information about this test"}
 
+    section_texts_all = [{'Actual section text' : a, 'Predicted section text' : p, 'Section' : s} for a,p,s in zip(actual, predicted, sections)]
+
+    section_texts_all = list(filter(lambda x: x['Actual section text'] != '', section_texts_all))
+
+    lev_distance = []
+    for section_texts in section_texts_all:
+        actual_text = section_texts['Actual section text']
+        predicted_text = section_texts['Predicted section text']
+        lev_distance.append(editdistance.eval(actual_text, predicted_text) / max(len(actual_text), len(predicted_text)))
+
+    # Sections for those that actually exist
+    sections_exist = [s['Section'] for s in section_texts_all]
+
+    # Which sections (of the texts that actual exist) were found exactly?
+    equal = [l==0 for l in lev_distance]
+    
+    # Which sections (of the texts that actual exist) were found roughly the same?
+    quite_equal = [l<levenshtein_threshold  for l in lev_distance]
+
+    test_scores = {
+        'Score' : sum(equal)/len(equal),
+        'Mean normalised Levenshtein distance' : np.mean(lev_distance),
+        'Strict accuracy (micro)' : sum(equal)/len(equal),
+        'Lenient accuracy (micro)' : sum(quite_equal)/len(quite_equal)}
+
+    strict_accuracies = []
+    lenient_accuracies = []
+    for section_name in set(sections_exist):
+        lev_distance_section = [e for i,e in enumerate(lev_distance) if sections_exist[i] == section_name]
+        equal_section = [l==0 for l in lev_distance_section]
+        quite_equal_section = [l<levenshtein_threshold  for l in lev_distance_section]
+        strict_acc_section = sum(equal_section)/len(equal_section)
+        lenient_acc_section = sum(quite_equal_section)/len(quite_equal_section)
+
+        test_scores['Mean normalised Levenshtein distance for the {} section'.format(section_name)] = np.mean(lev_distance_section)
+        test_scores['Strict accuracy for the {} section'.format(section_name)] = strict_acc_section
+        test_scores['Lenient accuracy for the {} section'.format(section_name)] = lenient_acc_section
+
+        strict_accuracies.append(strict_acc_section)
+        lenient_accuracies.append(lenient_acc_section)
+
+    test_scores['Strict accuracy (macro)'] = np.mean(strict_accuracies)
+    test_scores['Lenient accuracy (macro)'] = np.mean(lenient_accuracies)
+    
     return test_scores
 
-def scrape_pdfs(scrape_test_data):
+def scrape_pdfs(scrape_test_data, scrape_pdf_location):
+    """
+    Input
+    scrape_test_data: A nested dictionary of all the sections text for each pdf in the evaluation data,
+                in form {pdf_name1 : {section1 : 'text', section2 : 'text', ... },
+                        pdf_name2 : {section1 : 'text', section2 : 'text', ... }, ...}
+    Output
+    scrape_test_data: the evaluation dataframe now with whether a references section was
+        scraped or not, the text scraped for each of the 'sections' sections, and a re-formatted
+        actual references section text (in dictionary format)
+    """
 
-    references_text = []
+    # Predict the references text for these pdfs
 
-    for pdf in scrape_test_data['pdf']:
-        # data = scrape_function(pdf) #### NO IDEA HERE - SCRAPE THE PDF (file location to pdf/text of pdf) GIVEN
+    sections = scrape_test_data[next(iter(scrape_test_data))].keys()
+    text_results = {}
+    for pdf_name in scrape_test_data.keys():
+        with open('{}/{}.pdf'.format(scrape_pdf_location, pdf_name), 'r') as f:
+            pdf_file, full_text = parse_pdf_document(f)
+            section_dict = {}
+            for section in sections:
+                section_text = grab_section(pdf_file, section)
+                section_dict.update({section : section_text})
+            text_results.update({pdf_name : section_dict})
 
-        data = {'References section' : 'This was the references text.'} # Place holder
-        
-        if data['References section']:
-            references_text.append(data['References section']) #### NO IDEA HERE - GET THE REFERENCES SECTION TEXT SCRAPED
-        else:
-            references_text.append(None) # It might be that nothing is scraped
+    return text_results
 
-    scrape_test_data['References section text scraped'] = references_text
+def evaluate_find_section(scrape_test_data, scrape_pdf_location):
+    levenshtein_threshold = 0.3
 
-    return scrape_test_data
+    text_results = scrape_pdfs(scrape_test_data, scrape_pdf_location)
 
-def evaluate_find_section(scrape_test_data):
+    section_names = []
+    predicted_section = []
+    actual_section = []
+    for pdf_names in scrape_test_data.keys():
+        predicted_sections = text_results[pdf_names]
+        actual_sections = scrape_test_data[pdf_names]
+        for sections in actual_sections.keys():
+            predicted_section.append(predicted_sections[sections])
+            actual_section.append(actual_sections[sections])
+            section_names.append(sections)
 
-    test1_2_info = scrape_pdfs(scrape_test_data)
+    test1_scores = evaluate_metric_scraped(
+        [a!='' for a in actual_section], [p!='' for p in predicted_section],
+        section_names
+        )
 
-    test1_scores = evaluate_metric_scraped(test1_2_info['Has a references section?'], test1_2_info['References section text scraped'])
-
-    test2_scores = evaluate_metric_quality(test1_2_info['References section text'], test1_2_info['References section text scraped'])
+    test2_scores = evaluate_metric_quality(actual_section, predicted_section, section_names, levenshtein_threshold)
 
     return test1_scores, test2_scores
-
 

--- a/policytool/refparse/algo_evaluation/evaluate_find_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_find_section.py
@@ -1,20 +1,33 @@
-import sys
-sys.path.append("..")
-from pdf_parser.pdf_parse import parse_pdf_document, grab_section
-
-import os.path
+from sklearn.metrics import classification_report, f1_score, confusion_matrix
+import editdistance
 import pandas as pd
 import numpy as np
 
-from sklearn.metrics import classification_report, f1_score
-import editdistance
+import os.path
+import sys
 
-def evaluate_metric_scraped(actual, predicted, section_names):
+sys.path.append("..")
+from pdf_parser.pdf_parse import parse_pdf_document, grab_section
+
+
+def pretty_confusion_matrix(actual_data, predict_data, labels):
+    cm  = confusion_matrix(actual_data, predict_data, labels = labels)
+    pretty_conf = pd.DataFrame(
+        cm,
+        columns=["Predicted {}".format(label) for label in labels],
+        index=["Actually {}".format(label) for label in labels]
+        )
+    return pretty_conf
+
+def evaluate_metric_scraped(actual, predicted, sections):
     """
     Input:
         actual : a boolean list of whether section text was in the pdf
         predicted : a boolean list of whether section text was scraped
-        section_names : a list of the section names
+        sections : a list of the section names for each actual/predicted pair
+    Output:
+        Various metrics for how accurately the scraper scraped a
+        section or not, no comment on how good the scrape was though
     """
 
     similarity = round(f1_score(actual, predicted, average='micro'), 3)
@@ -22,117 +35,142 @@ def evaluate_metric_scraped(actual, predicted, section_names):
     test_scores = {
         'Score' : similarity,
         'Micro average F1-score' : similarity,
-        'Classification report' : classification_report(actual, predicted) 
+        'Classification report' : classification_report(actual, predicted),
+        'Confusion matrix' : pretty_confusion_matrix(
+                actual, predicted, [True, False]
+            )
         }
 
-    for section_name in set(section_names):
-        has_section = [e for i,e in enumerate(actual) if section_names[i] == section_name]
-        has_scraped_section = [e for i,e in enumerate(predicted) if section_names[i] == section_name]
-        test_scores["Classification report for the {} section".format(section_name)] = classification_report(has_section, has_scraped_section)
+    for section_name in set(sections):
+        actual_section = [
+            a for (s,a) in zip(sections, actual) if s == section_name
+        ]
+        predicted_section = [
+            p for (s,p) in zip(sections, predicted) if s == section_name
+        ]
+        test_scores["Classification report for the {} section".format(
+            section_name
+            )] = classification_report(actual_section, predicted_section)
+        test_scores["Confusion matrix for the {} section".format(
+            section_name
+            )] = pretty_confusion_matrix(
+                    actual_section, predicted_section, [True, False]
+                )
 
     return test_scores
 
 
-def evaluate_metric_quality(actual, predicted, sections, levenshtein_threshold):
+def evaluate_metric_quality(scrape_data, levenshtein_threshold):
     """
-    Text similarity for when there is a section (actual!='')
+    Normalised Levenshtein distances between actual and predicted section text
+    for pdfs where there is a section (actual!='')
     """
 
-    section_texts_all = [{'Actual section text' : a, 'Predicted section text' : p, 'Section' : s} for a,p,s in zip(actual, predicted, sections)]
+    # Get rid of times when there is no section
+    scrape_data = list(filter(lambda x: x['Actual text'] != '', scrape_data))
 
-    section_texts_all = list(filter(lambda x: x['Actual section text'] != '', section_texts_all))
+    actual_texts = [s['Actual text'] for s in scrape_data]
+    predicted_texts = [s['Predicted text'] for s in scrape_data]
+    sections = [s['Section'] for s in scrape_data]
 
-    lev_distance = []
-    for section_texts in section_texts_all:
-        actual_text = section_texts['Actual section text']
-        predicted_text = section_texts['Predicted section text']
-        lev_distance.append(editdistance.eval(actual_text, predicted_text) / max(len(actual_text), len(predicted_text)))
+    # Get all the normalised Lev distances
+    lev_distances = [
+        editdistance.eval(actual_text, predicted_text) / 
+        max(len(actual_text), len(predicted_text)) \
+        for (actual_text, predicted_text) in 
+            zip(actual_texts, predicted_texts)
+    ]   
 
-    # Sections for those that actually exist
-    sections_exist = [s['Section'] for s in section_texts_all]
-
-    # Which sections (of the texts that actual exist) were found exactly?
-    equal = [l==0 for l in lev_distance]
+    # Which sections were found exactly?
+    equal = [lev_distance == 0 for lev_distance in lev_distances]
     
-    # Which sections (of the texts that actual exist) were found roughly the same?
-    quite_equal = [l<levenshtein_threshold  for l in lev_distance]
+    # Which sections were found roughly the same?
+    quite_equal = [
+        lev_distance<levenshtein_threshold  for lev_distance in lev_distances
+    ]
 
     test_scores = {
-        'Score' : sum(equal)/len(equal),
-        'Mean normalised Levenshtein distance' : np.mean(lev_distance),
-        'Strict accuracy (micro)' : sum(equal)/len(equal),
-        'Lenient accuracy (micro)' : sum(quite_equal)/len(quite_equal)}
+        'Score' : np.mean(equal),
+        'Mean normalised Levenshtein distance' : np.mean(lev_distances),
+        'Strict accuracy (micro)' : np.mean(equal),
+        'Lenient accuracy (micro)' : np.mean(quite_equal)}
 
-    strict_accuracies = []
-    lenient_accuracies = []
-    for section_name in set(sections_exist):
-        lev_distance_section = [e for i,e in enumerate(lev_distance) if sections_exist[i] == section_name]
-        equal_section = [l==0 for l in lev_distance_section]
-        quite_equal_section = [l<levenshtein_threshold  for l in lev_distance_section]
-        strict_acc_section = sum(equal_section)/len(equal_section)
-        lenient_acc_section = sum(quite_equal_section)/len(quite_equal_section)
+    for section_name in set(sections):
+        # Get the Levenshtein distances for this sections actual-predicted pairs
+        lev_distances_section = [
+                lev_distance for (section,lev_distance) \
+                in zip(sections, lev_distances) \
+                if section == section_name
+            ]
 
-        test_scores['Mean normalised Levenshtein distance for the {} section'.format(section_name)] = np.mean(lev_distance_section)
-        test_scores['Strict accuracy for the {} section'.format(section_name)] = strict_acc_section
-        test_scores['Lenient accuracy for the {} section'.format(section_name)] = lenient_acc_section
+        equal_section = [l==0 for l in lev_distances_section]
+        quite_equal_section = [
+            l<levenshtein_threshold  for l in lev_distances_section
+        ]
+        strict_acc_section = np.mean(equal_section)
+        lenient_acc_section = np.mean(quite_equal_section)
 
-        strict_accuracies.append(strict_acc_section)
-        lenient_accuracies.append(lenient_acc_section)
-
-    test_scores['Strict accuracy (macro)'] = np.mean(strict_accuracies)
-    test_scores['Lenient accuracy (macro)'] = np.mean(lenient_accuracies)
+        test_scores[
+            'Mean normalised Levenshtein distance for the {} section'.format(
+                section_name
+                )
+            ] = np.mean(lev_distances_section)
+        test_scores[
+            'Strict accuracy for the {} section'.format(section_name)
+            ] = strict_acc_section
+        test_scores[
+            'Lenient accuracy for the {} section'.format(section_name)
+            ] = lenient_acc_section
     
     return test_scores
 
-def scrape_pdfs(scrape_test_data, scrape_pdf_location):
+def scrape_process_pdf(
+        section_names, pdf_name, scrape_pdf_location, actual_texts
+        ):
     """
-    Input
-    scrape_test_data: A nested dictionary of all the sections text for each pdf in the evaluation data,
-                in form {pdf_name1 : {section1 : 'text', section2 : 'text', ... },
-                        pdf_name2 : {section1 : 'text', section2 : 'text', ... }, ...}
-    Output
-    scrape_test_data: the evaluation dataframe now with whether a references section was
-        scraped or not, the text scraped for each of the 'sections' sections, and a re-formatted
-        actual references section text (in dictionary format)
+    Input:
+        section_names :  the list of sections we are looking for in the pdf
+        pdf_name : the name of the pdf
+        scrape_pdf_location : the file location of the pdf
+    Output:
+        scrape_data : a list of dicts with the predicted and actual texts for
+            each of the sections we looked for in the pdf
     """
+    with open('{}/{}.pdf'.format(scrape_pdf_location, pdf_name), 'r') as f:
+        pdf_file, full_text = parse_pdf_document(f)
+        scrape_data = []
+        for section_name in section_names:
+            scrape_data.append({
+                'File' : pdf_name,
+                'Section' : section_name,
+                'Predicted text' : grab_section(pdf_file, section_name),
+                'Actual text' : actual_texts[section_name]})
+    return scrape_data
 
-    # Predict the references text for these pdfs
 
-    sections = scrape_test_data[next(iter(scrape_test_data))].keys()
-    text_results = {}
-    for pdf_name in scrape_test_data.keys():
-        with open('{}/{}.pdf'.format(scrape_pdf_location, pdf_name), 'r') as f:
-            pdf_file, full_text = parse_pdf_document(f)
-            section_dict = {}
-            for section in sections:
-                section_text = grab_section(pdf_file, section)
-                section_dict.update({section : section_text})
-            text_results.update({pdf_name : section_dict})
+def evaluate_find_section(
+        evaluate_find_section_data, scrape_pdf_location, levenshtein_threshold
+        ):
 
-    return text_results
-
-def evaluate_find_section(scrape_test_data, scrape_pdf_location):
-    levenshtein_threshold = 0.3
-
-    text_results = scrape_pdfs(scrape_test_data, scrape_pdf_location)
-
-    section_names = []
-    predicted_section = []
-    actual_section = []
-    for pdf_names in scrape_test_data.keys():
-        predicted_sections = text_results[pdf_names]
-        actual_sections = scrape_test_data[pdf_names]
-        for sections in actual_sections.keys():
-            predicted_section.append(predicted_sections[sections])
-            actual_section.append(actual_sections[sections])
-            section_names.append(sections)
+    # Get the predicted text for each of the pdf sections for each pdf
+    section_names = evaluate_find_section_data[
+        next(iter(evaluate_find_section_data))
+        ].keys()
+    scrape_data = []
+    for pdf_name, actual_texts in evaluate_find_section_data.items():
+        scrape_data.extend(
+            scrape_process_pdf(section_names, pdf_name, scrape_pdf_location, actual_texts)
+            ) 
 
     test1_scores = evaluate_metric_scraped(
-        [a!='' for a in actual_section], [p!='' for p in predicted_section],
-        section_names
+        [pred_section['Actual text']!='' for pred_section in scrape_data],
+        [pred_section['Predicted text']!='' for pred_section in scrape_data],
+        [pred_section['Section'] for pred_section in scrape_data]
         )
 
-    test2_scores = evaluate_metric_quality(actual_section, predicted_section, section_names, levenshtein_threshold)
+    test2_scores = evaluate_metric_quality(
+        scrape_data,
+        levenshtein_threshold)
 
     return test1_scores, test2_scores
 

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -4,7 +4,9 @@ from settings import BaseSettings
 class TestSettings(BaseSettings):
 
     SPLIT_SECTION_SIMILARITY_THRESHOLD = 40
+
     LEVENSHTEIN_DIST_THRESHOLD = 0.3
+    LEVENSHTEIN_DIST_SCRAPER_THRESHOLD = 0.3
 
     FOLDER_PREFIX = "./algo_evaluation/data_evaluate"
     LOG_FILE_PREFIX = './algo_evaluation/results'

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -17,6 +17,9 @@ class TestSettings(BaseSettings):
     NUM_REFS_FILE_NAME = "split_section_test_data.csv"
     NUM_REFS_TEXT_FOLDER_NAME = "scraped_references_sections"
 
+    MODEL_FILE_TYPE = 'pickle'
+    MODEL_FILE_PREFIX = './reference_parser_models/'
+    MODEL_FILE_NAME = 'reference_parser_pipeline.pkl'
     PARSE_REFERENCE_FILE_NAME = "actual_reference_structures_sample.csv"
 
     TEST_PUB_DATA_FILE_NAME = "positive_and_negative_match_test_data.csv"

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -9,7 +9,8 @@ class TestSettings(BaseSettings):
     FOLDER_PREFIX = "./algo_evaluation/data_evaluate"
     LOG_FILE_PREFIX = './algo_evaluation/results'
 
-    SCRAPE_DATA_FILE_NAME = "scrape_test_data.csv"
+    SCRAPE_DATA_PDF_FOLDER_NAME = "pdfs"
+    SCRAPE_DATA_REF_PDF_FOLDER_NAME = "pdf_sections"
 
     NUM_REFS_FILE_NAME = "split_section_test_data.csv"
     NUM_REFS_TEXT_FOLDER_NAME = "scraped_references_sections"

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -4,6 +4,7 @@ e.g. python test_algo.py --verbose True
 
 from argparse import ArgumentParser
 import os
+from os import listdir 
 
 from utils import FileManager
 from datetime import datetime
@@ -20,10 +21,56 @@ def get_references_sections(filenames, foldername):
 
     references_sections = []
     for filename in filenames:
-        section = open("{}/{}.txt".format(foldername, filename)).read()
+        try:
+            section = open("{}/{}.txt".format(foldername, filename)).read()
+        except:
+            section = ""
         references_sections.append(section)
 
     return references_sections
+
+def get_sections_text_dict(pdf_names, sections_folder_names, sections_location):
+    """
+    For each pdf in the evaluation data, get all the text from each txt file in the location given
+    
+    Input:
+    pdf_names : A list of the pdf names in the evaluation data 
+                e.g [pdf_name1, pdf_name2, ...]
+    sections_folder_names : 
+                A list of the folder names for each section we have evaluation data for
+                e.g. ['reference', 'bibliograph']
+    sections_location : 
+                The file location where each of the section folders are kept
+                e.g './algo_evaluation/data_evaluate/pdf_sections'
+
+    Output:
+    sections_dict : 
+                A nested dictionary of all the sections text for each pdf in the evaluation data,
+                in form {pdf_name1 : {section1 : 'text', section2 : 'text', ... },
+                        pdf_name2 : {section1 : 'text', section2 : 'text', ... }, ...}
+    """
+
+    # Get the text for each section for each pdf
+    sections = [pdf_names]
+    for section_folder in sections_folder_names:
+        section_text = get_references_sections(
+            pdf_names,
+            '{}/{}'.format(
+                sections_location,
+                section_folder
+                )
+            )
+        sections.append(section_text)
+
+    sections_dict = {}
+    for p, *r in zip(*sections):
+        sections = {}
+        for i, section_folder in enumerate(sections_folder_names):
+            sections.update({section_folder : r[i]})
+        sections_dict.update({p: sections})
+
+    return sections_dict
+
 
 def create_argparser():
     parser = ArgumentParser()
@@ -58,12 +105,18 @@ if __name__ == '__main__':
     fm = FileManager()
 
     # Load data to test scraping for tests 1 and 2:
-    logger.info('[+] Reading {}'.format(settings.SCRAPE_DATA_FILE_NAME))
-    scrape_test_data = fm.get_file(
-        settings.SCRAPE_DATA_FILE_NAME,
-        settings.FOLDER_PREFIX,
-        'csv'
-    )
+    logger.info('[+] Reading {}'.format(settings.SCRAPE_DATA_PDF_FOLDER_NAME))
+
+    # Get the pdf names from the evaluate scraping folder:
+    scrape_pdf_location = '{}/{}'.format(settings.FOLDER_PREFIX,settings.SCRAPE_DATA_PDF_FOLDER_NAME)
+    pdf_names = listdir(scrape_pdf_location)
+    pdf_names = [os.path.splitext(pdf_name)[0] for pdf_name in pdf_names]
+    pdf_names.remove('.DS_Store')
+
+    sections_location = '{}/{}'.format(settings.FOLDER_PREFIX,settings.SCRAPE_DATA_REF_PDF_FOLDER_NAME)
+    sections_folder_names = [name for name in os.listdir(sections_location) if os.path.isdir('{}/{}'.format(sections_location, name))]
+
+    scrape_test_data = get_sections_text_dict(pdf_names, sections_folder_names, sections_location)
 
     # Load data to test split sections for test 3:
     logger.info('[+] Reading {}'.format(settings.NUM_REFS_FILE_NAME))
@@ -110,8 +163,9 @@ if __name__ == '__main__':
 
     logger.info('\nStarting the tests...\n')
 
-    logger.info('[+] Running tests 1 and 2')
-    test1_scores, test2_scores = evaluate_find_section(scrape_test_data)
+    logger.info('[+] Running tests 1 and 2')                     
+
+    test1_scores, test2_scores = evaluate_find_section(scrape_test_data, scrape_pdf_location)
 
     logger.info('[+] Running test 3')
     test3_scores = evaluate_split_section(

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -5,11 +5,10 @@ e.g. python test_algo.py --verbose True
 from argparse import ArgumentParser
 import os
 from os import listdir 
-
-from utils import FileManager
 from datetime import datetime
 from urllib.parse import urlparse
 
+from utils import FileManager
 from algo_evaluation.evaluate_settings import settings
 from algo_evaluation.evaluate_find_section import evaluate_find_section
 from algo_evaluation.evaluate_split_section import evaluate_split_section
@@ -17,66 +16,61 @@ from algo_evaluation.evaluate_parse import evaluate_parse
 from algo_evaluation.evaluate_match_references import evaluate_match_references
 
 
-def get_references_sections(filenames, foldername):
+def get_text(filename, foldername):
 
-    references_sections = []
-    for filename in filenames:
-        try:
-            section = open("{}/{}.txt".format(foldername, filename)).read()
-        except:
-            section = ""
-        references_sections.append(section)
+    try:
+        references_section = open(
+            "{}/{}.txt".format(foldername, filename)
+        ).read()
+    except:
+        references_section = ""
 
-    return references_sections
+    return references_section
 
-def get_sections_text_dict(pdf_names, sections_folder_names, sections_location):
+def get_pdf_sections(
+        pdf_name, sections_folder_names, sections_location
+        ):
     """
-    For each pdf in the evaluation data, get all the text from each txt file in the location given
+    For a pdf name in the evaluation data, 
+    get all the text from any relevant txt files in the locations given
     
     Input:
-    pdf_names : A list of the pdf names in the evaluation data 
-                e.g [pdf_name1, pdf_name2, ...]
+    pdf_name : A pdf name in the evaluation data 
+                e.g pdf_name1
     sections_folder_names : 
-                A list of the folder names for each section we have evaluation data for
+                A list of the folder names for each
+                section we have evaluation data for
                 e.g. ['reference', 'bibliograph']
     sections_location : 
-                The file location where each of the section folders are kept
+                The file location where each of the
+                section folders are kept
                 e.g './algo_evaluation/data_evaluate/pdf_sections'
 
     Output:
     sections_dict : 
-                A nested dictionary of all the sections text for each pdf in the evaluation data,
-                in form {pdf_name1 : {section1 : 'text', section2 : 'text', ... },
-                        pdf_name2 : {section1 : 'text', section2 : 'text', ... }, ...}
+                A dictionary of all the sections text
+                for this pdf,
+                in form {reference : 'text', bibliograph : 'text', ... }
     """
-
-    # Get the text for each section for each pdf
-    sections = [pdf_names]
+    sections = {}
     for section_folder in sections_folder_names:
-        section_text = get_references_sections(
-            pdf_names,
+        section_text = get_text(
+            pdf_name,
             '{}/{}'.format(
                 sections_location,
                 section_folder
                 )
             )
-        sections.append(section_text)
-
-    sections_dict = {}
-    for p, *r in zip(*sections):
-        sections = {}
-        for i, section_folder in enumerate(sections_folder_names):
-            sections.update({section_folder : r[i]})
-        sections_dict.update({p: sections})
-
-    return sections_dict
-
+        sections.update({section_folder : section_text})
+    
+    return sections
 
 def create_argparser():
     parser = ArgumentParser()
     parser.add_argument(
         '--verbose',
-        help='Whether you want to print detailed test information ("True") or not ("False")',
+        help='Whether you want to print detailed test \
+            information ("True") or not ("False")',
         default = True
     )
 
@@ -94,55 +88,78 @@ if __name__ == '__main__':
     logger.info('Starting tests...')
 
     log_file = open(
-        '{}/Test results - {:%Y-%m-%d-%H%M}'.format(settings.LOG_FILE_PREFIX, now), 'w'
-        )
+        '{}/Test results - {:%Y-%m-%d-%H%M}'.format(
+            settings.LOG_FILE_PREFIX, now
+        ), 'w'
+    )
         
     log_file.write(
         'Date of test = {:%Y-%m-%d-%H%M}\n'.format(now)
-        )
+    )
 
     logger.info('Reading files...')
     fm = FileManager()
 
-    # Load data to test scraping for tests 1 and 2:
-    logger.info('[+] Reading {}'.format(settings.SCRAPE_DATA_PDF_FOLDER_NAME))
+    # ==== Load data to test scraping for tests 1 and 2: ====
+    logger.info('[+] Reading {}'.format(
+        settings.SCRAPE_DATA_PDF_FOLDER_NAME
+        )
+    )
 
-    # Get the pdf names from the evaluate scraping folder:
-    scrape_pdf_location = '{}/{}'.format(settings.FOLDER_PREFIX,settings.SCRAPE_DATA_PDF_FOLDER_NAME)
+    scrape_pdf_location = '{}/{}'.format(
+        settings.FOLDER_PREFIX,
+        settings.SCRAPE_DATA_PDF_FOLDER_NAME
+    )
+
     pdf_names = listdir(scrape_pdf_location)
-    pdf_names = [os.path.splitext(pdf_name)[0] for pdf_name in pdf_names]
+    pdf_names = [
+        os.path.splitext(pdf_name)[0] for pdf_name in pdf_names
+    ]
     pdf_names.remove('.DS_Store')
 
-    sections_location = '{}/{}'.format(settings.FOLDER_PREFIX,settings.SCRAPE_DATA_REF_PDF_FOLDER_NAME)
-    sections_folder_names = [name for name in os.listdir(sections_location) if os.path.isdir('{}/{}'.format(sections_location, name))]
+    sections_location = '{}/{}'.format(
+        settings.FOLDER_PREFIX,
+        settings.SCRAPE_DATA_REF_PDF_FOLDER_NAME
+    )
 
-    scrape_test_data = get_sections_text_dict(pdf_names, sections_folder_names, sections_location)
+    sections_folder_names = [
+        name for name in os.listdir(sections_location) \
+        if os.path.isdir('{}/{}'.format(sections_location, name))
+    ]
 
-    # Load data to test split sections for test 3:
+    evaluate_find_section_data = {
+        pdf_name : get_pdf_sections(
+            pdf_name, sections_folder_names, sections_location
+        ) for pdf_name in pdf_names
+    }
+
+    # ==== Load data to test split sections for test 3: ====
     logger.info('[+] Reading {}'.format(settings.NUM_REFS_FILE_NAME))
-    split_section_test_data = fm.get_file(
+    evaluate_split_section_data = fm.get_file(
         settings.NUM_REFS_FILE_NAME,
         settings.FOLDER_PREFIX,
         'csv'
     )
-    references_sections = get_references_sections(
-                            split_section_test_data['hash'],
-                            '{}/{}'.format(
-                                settings.FOLDER_PREFIX,
-                                settings.NUM_REFS_TEXT_FOLDER_NAME
-                                )
-                            )
-    split_section_test_data['Reference section'] = references_sections
 
-    # Load data to test parse for test 4:
+    evaluate_split_section_data['Reference section'] = [
+        get_text(
+            doc_hash,
+            '{}/{}'.format(
+                settings.FOLDER_PREFIX,
+                settings.NUM_REFS_TEXT_FOLDER_NAME
+                )
+            ) for doc_hash in evaluate_split_section_data['hash']
+        ]
+
+    # ==== Load data to test parse for test 4: ====
     logger.info('[+] Reading {}'.format(settings.PARSE_REFERENCE_FILE_NAME))
-    parse_test_data = fm.get_file(
+    evaluate_parse_data = fm.get_file(
         settings.PARSE_REFERENCE_FILE_NAME,
         settings.FOLDER_PREFIX,
         'csv'
     )
 
-    # Load data to test matching for test 5:
+    # ==== Load data to test matching for test 5: ====
     logger.info('[+] Reading {}'.format(settings.TEST_PUB_DATA_FILE_NAME))
     evaluation_references = fm.get_file(
         settings.TEST_PUB_DATA_FILE_NAME,
@@ -159,32 +176,49 @@ if __name__ == '__main__':
     )
 
     # Load the latest parser model
-    model = fm.get_file('reference_parser_pipeline.pkl','./reference_parser_models/','pickle')
+    model = fm.get_file(
+        'reference_parser_pipeline.pkl',
+        './reference_parser_models/',
+        'pickle'
+    )
 
+    # ==== Get the evaluation metrics ====
     logger.info('\nStarting the tests...\n')
 
     logger.info('[+] Running tests 1 and 2')                     
 
-    test1_scores, test2_scores = evaluate_find_section(scrape_test_data, scrape_pdf_location)
+    test1_scores, test2_scores = evaluate_find_section(
+        evaluate_find_section_data,
+        scrape_pdf_location,
+        settings.LEVENSHTEIN_DIST_SCRAPER_THRESHOLD
+    )
 
     logger.info('[+] Running test 3')
     test3_scores = evaluate_split_section(
-        split_section_test_data,
+        evaluate_split_section_data,
         settings.ORGANISATION_REGEX,
         settings.SPLIT_SECTION_SIMILARITY_THRESHOLD
         )
 
     logger.info('[+] Running test 4')
+
     test4_scores = evaluate_parse(parse_test_data, model, settings.LEVENSHTEIN_DIST_THRESHOLD)
 
     logger.info('[+] Running test 5')
     test5_scores = evaluate_match_references(publications, evaluation_references, settings.FUZZYMATCH_THRESHOLD)
 
     test_scores_list = [test1_scores, test2_scores, test3_scores, test4_scores, test5_scores]
+
     if args.verbose:
         for i, tests in enumerate(test_scores_list):
-            log_file.write("\n-----Information about test {}:-----\n".format(i))
-            [log_file.write("\n"+k+"\n"+str(v)+"\n") for (k,v) in tests.items()]
+            log_file.write(
+                "\n-----Information about test {}:-----\n".format(i)
+            )
+            [
+                log_file.write(
+                    "\n"+k+"\n"+str(v)+"\n"
+                ) for (k,v) in tests.items()
+            ]
     else:
         for i, tests in enumerate(test_scores_list):
             log_file.write("\nScore for test {}:\n".format(i))


### PR DESCRIPTION
Note you will need my testing data for this (temporary until I actually get the real policy pdf data). Download the 'pdf_sections' and 'pdfs' folders in https://s3.console.aws.amazon.com/s3/buckets/datalabs-data/policy_tool_tests/?region=us-east-2&tab=overview and put them in the 'data_evaluate' folder.

# TO DO 

- Get the actual evaluation data! (currently test pdfs) (can still review this PR without this though, but would be nice to check it doesn't fail or anything once we have the proper data)

# Description

This involved significant work at working out how the test would work, so I have had to redesign what the evaluation data looks like, and import the new type and process accordingly (in `evaluate_algo.py`).

I have rewritten most of the layout I had designed in `evaluate_find_section.py`, and imported different files (editing `evaluate_settings.py`). I've also added a bit of text to the README about importing poppler to make this evaluation work.

I also found an error in `../pdf_parser/main.py` - the file path no longer existed, so I've corrected this file path.

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [x] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

No tests.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
