### PR TITLE
Provider metadata in evaluation of find sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ aws s3 cp --recursive s3://datalabs-data/policy_tool_tests algo_evaluation/data_
 ```
 and then running
 ```
-python evaluate_algo.py --verbose True
+python evaluate_algo.py
 ```
-(or set the verbose argument to False if you want less information about the evaluation to be printed).
+(or set the verbose argument to False (`python evaluate_algo.py --verbose False`) if you want less information about the evaluation to be printed).
 
 You can read more about how we got the evaluation data and what the evaluation results mean [here](docs/evaluation_data.md).
 

--- a/policytool/refparse/algo_evaluation/evaluate_find_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_find_section.py
@@ -19,45 +19,6 @@ def pretty_confusion_matrix(actual_data, predict_data, labels):
         )
     return pretty_conf
 
-def metrics_by_provider(combined_data, all_providers): 
-
-    func_num_pdfs = lambda x: len(x["Files"].unique())
-    func_num_pdfs_text = lambda x: len(x[x["Actual"]==True]["Files"].unique())
-    func_prop_text = lambda x: round(sum(x["Actual"]==True) / len(x), 3)
-    func_f1 = lambda x: round(f1_score(list(x["Actual"]), list(x["Predicted"]), average='micro'), 3)
-    
-    grouped_provider = combined_data.groupby("Provider")
-
-    prov_n = grouped_provider.apply(func_num_pdfs)
-    prov_n_text = grouped_provider.apply(func_num_pdfs_text)
-    prov_prop_text = round(prov_n_text/prov_n, 3)
-    prov_f1 = grouped_provider.apply(func_f1)
-
-    grouped_provider_section = combined_data.groupby(["Provider","Section"])
-
-    sect_n_text = grouped_provider_section.apply(func_num_pdfs_text)
-    sect_prop_text = grouped_provider_section.apply(func_prop_text)
-    sect_f1 = grouped_provider_section.apply(func_f1)
-
-    prov_metrics = pd.concat([prov_n, prov_n_text, prov_prop_text, prov_f1], axis = 1)
-    prov_metrics.columns = [
-        "Number of pdfs included",
-        "Number of pdfs with sections text",
-        "Proportion of pdfs with sections text",
-        "F1 score for all sections included"
-        ]
-
-    trans_sect_n_text = pd.DataFrame([sect_n_text[provider] for provider in all_providers], index = all_providers)
-    trans_sect_n_text.columns = ['Number of pdfs with a {} section'.format(b) for b in trans_sect_n_text.columns]
-    trans_sect_prop_text = pd.DataFrame([sect_prop_text[provider] for provider in all_providers], index = all_providers)
-    trans_sect_prop_text.columns = ['Proportion with a {} section'.format(b) for b in trans_sect_prop_text.columns]
-    trans_sect_f1 = pd.DataFrame([sect_f1[provider] for provider in all_providers], index = all_providers)
-    trans_sect_f1.columns = ['F1 score for the {} section'.format(b) for b in trans_sect_f1.columns]
-
-    provider_metrics = pd.concat([prov_metrics, trans_sect_n_text, trans_sect_prop_text, trans_sect_f1], axis = 1)
-
-    return provider_metrics
-
 def evaluate_metric_scraped(actual, predicted, sections, files, providers):
     """
     Input:
@@ -73,17 +34,92 @@ def evaluate_metric_scraped(actual, predicted, sections, files, providers):
 
     similarity = round(f1_score(actual, predicted, average='micro'), 3)
 
-    combined_data = pd.DataFrame([actual, predicted, sections, files, providers]).T
-    combined_data.columns = ["Actual", "Predicted", "Section", "Files", "Provider"]
+    combined_data = pd.DataFrame({
+        'Actual' : actual,
+        'Predicted' : predicted,
+        'Section' : sections,
+        'Files' : files, 
+        'Provider' : providers
+        })
 
-    provider_metrics = metrics_by_provider(combined_data, list(set(providers)))
+    all_providers = list(set(providers))
+
+    get_num_pdfs = lambda x: len(x["Files"].unique())
+    get_num_pdfs_text = lambda x: len(x[x["Actual"]==True]["Files"].unique())
+    get_prop_text = lambda x: round(sum(x["Actual"]==True) / len(x), 3)
+    get_f1 = lambda x: round(
+        f1_score(
+            list(x["Actual"]),
+            list(x["Predicted"]),
+            average='micro'
+            ),
+        3
+        )
+    
+    grouped_provider = combined_data.groupby("Provider")
+
+    n_by_prov = grouped_provider.apply(get_num_pdfs)
+    n_text_by_prov = grouped_provider.apply(get_num_pdfs_text)
+    prop_text_by_prov = round(n_text_by_prov/n_by_prov, 3)
+    f1_by_prov = grouped_provider.apply(get_f1)
+
+    grouped_provider_section = combined_data.groupby(["Provider","Section"])
+
+    n_text_by_sect = grouped_provider_section.apply(get_num_pdfs_text)
+    prop_text_by_sect = grouped_provider_section.apply(get_prop_text)
+    f1_by_sect = grouped_provider_section.apply(get_f1)
+
+    metrics_by_prov = pd.concat(
+        [n_by_prov, n_text_by_prov, prop_text_by_prov, f1_by_prov],
+        axis = 1
+        )
+    metrics_by_prov.columns = [
+        "Number of pdfs included",
+        "Number of pdfs with sections text",
+        "Proportion of pdfs with sections text",
+        "F1 score for all sections included"
+        ]
+
+    trans_n_text_by_sect = pd.DataFrame(
+        [n_text_by_sect[provider] for provider in all_providers],
+        index = all_providers
+        )
+    trans_n_text_by_sect.columns = [
+        'Number of pdfs with a {} section'.format(b)\
+        for b in trans_n_text_by_sect.columns
+        ]
+    trans_prop_text_by_sect = pd.DataFrame(
+        [prop_text_by_sect[provider] for provider in all_providers],
+        index = all_providers
+        )
+    trans_prop_text_by_sect.columns = [
+        'Proportion with a {} section'.format(b)\
+        for b in trans_prop_text_by_sect.columns
+        ]
+    trans_f1_by_sect = pd.DataFrame(
+        [f1_by_sect[provider] for provider in all_providers],
+        index = all_providers
+        )
+    trans_f1_by_sect.columns = [
+        'F1 score for the {} section'.format(b)\
+        for b in trans_f1_by_sect.columns
+        ]
+
+    provider_metrics = pd.concat(
+        [metrics_by_prov, trans_n_text_by_sect,
+        trans_prop_text_by_sect, trans_f1_by_sect],
+        axis = 1
+        )
+    provider_metrics = (provider_metrics.T).to_string()
 
     metrics = {
         'Score' : similarity,
         'F1-score' : similarity,
-        'Metrics by provider' : (provider_metrics.T).to_string(),
+        'Metrics by provider' : provider_metrics,
         'Number of unique pdfs' : len(set(files)),
-        'Number of pdfs with a section text' : len(set([f for (f,a) in zip(files, actual) if a])),
+        'Number of pdfs with a section text' : len(
+            set([f for (f,a) in zip(files, actual) if a])
+            ),
         'Classification report' : classification_report(actual, predicted),
         'Confusion matrix' : pretty_confusion_matrix(
                 actual, predicted, [True, False]
@@ -208,7 +244,8 @@ def scrape_process_pdf(
 
 
 def evaluate_find_section(
-        evaluate_find_section_data, provider_names, scrape_pdf_location, levenshtein_threshold
+        evaluate_find_section_data, provider_names,
+        scrape_pdf_location, levenshtein_threshold
         ):
 
     # Get the predicted text for each of the pdf sections for each pdf
@@ -218,7 +255,9 @@ def evaluate_find_section(
     scrape_data = []
     for pdf_name, actual_texts in evaluate_find_section_data.items():
         scrape_data.extend(
-            scrape_process_pdf(section_names, pdf_name, scrape_pdf_location, actual_texts)
+            scrape_process_pdf(
+                section_names, pdf_name, scrape_pdf_location, actual_texts
+                )
             )
 
     eval1_scores = evaluate_metric_scraped(

--- a/policytool/refparse/algo_evaluation/evaluate_find_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_find_section.py
@@ -83,7 +83,7 @@ def evaluate_metric_scraped(actual, predicted, sections, files, providers):
         'F1-score' : similarity,
         'Metrics by provider' : (provider_metrics.T).to_string(),
         'Number of unique pdfs' : len(set(files)),
-        'Number of pdfs with a section text' : len(set([f for (f,a) in zip(files, actual) if actual])),
+        'Number of pdfs with a section text' : len(set([f for (f,a) in zip(files, actual) if a])),
         'Classification report' : classification_report(actual, predicted),
         'Confusion matrix' : pretty_confusion_matrix(
                 actual, predicted, [True, False]

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -10,6 +10,7 @@ class TestSettings(BaseSettings):
     LEVENSHTEIN_DIST_SCRAPER_THRESHOLD = 0.3
     SCRAPE_DATA_PDF_FOLDER_NAME = "pdfs"
     SCRAPE_DATA_REF_PDF_FOLDER_NAME = "pdf_sections"
+    SCRAPE_DATA_PROVIDERS_FILE_NAME = "pdfs_providers.csv"
 
     # Variables for split section evaluation data
     SPLIT_SECTION_SIMILARITY_THRESHOLD = 40

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -10,7 +10,7 @@ class TestSettings(BaseSettings):
     LEVENSHTEIN_DIST_SCRAPER_THRESHOLD = 0.3
     SCRAPE_DATA_PDF_FOLDER_NAME = "pdfs"
     SCRAPE_DATA_REF_PDF_FOLDER_NAME = "pdf_sections"
-    SCRAPE_DATA_PROVIDERS_FILE_NAME = "pdfs_providers.csv"
+    SCRAPE_DATA_PROVIDERS_FILE_NAME = "pdf_providers.csv"
 
     # Variables for split section evaluation data
     SPLIT_SECTION_SIMILARITY_THRESHOLD = 40

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     logger.info('Starting evaluations...')
 
     log_file = open(
-        '{}/Evaluation results - {:%Y-%m-%d-%H%M}'.format(
+        '{}/Evaluation results - {:%Y-%m-%d-%H%M}.txt'.format(
             settings.LOG_FILE_PREFIX, now
         ), 'w'
     )

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -95,8 +95,18 @@ if __name__ == '__main__':
         settings.SCRAPE_DATA_REF_PDF_FOLDER_NAME
     )
 
+    provider_names = fm.get_file(
+        settings.SCRAPE_DATA_PROVIDERS_FILE_NAME,
+        settings.FOLDER_PREFIX,
+        'csv'
+    )
+    # Convert to dictionary for ease of use
+    provider_names = provider_names.set_index('file_hash')['name'].to_dict()
+
     evaluate_find_section_data = defaultdict(lambda: defaultdict(str))
-    for pdf_hash, section_name, section_text in yield_section_data(scrape_pdf_location, sections_location):
+    for pdf_hash, section_name, section_text in yield_section_data(
+            scrape_pdf_location, sections_location
+        ):
         evaluate_find_section_data[pdf_hash][section_name] = section_text
 
     # ==== Load data to evaluate split sections for evaluations 3: ====
@@ -156,6 +166,7 @@ if __name__ == '__main__':
     logger.info('[+] Running evaluations 1 and 2')                     
     eval1_scores, eval2_scores = evaluate_find_section(
         evaluate_find_section_data,
+        provider_names,
         scrape_pdf_location,
         settings.LEVENSHTEIN_DIST_SCRAPER_THRESHOLD
     )


### PR DESCRIPTION
This runs with the new real policy document data, so you need to re-download:
1. the pdf_sections folder: https://s3.console.aws.amazon.com/s3/buckets/datalabs-data/policy_tool_tests/pdf_sections/?region=us-east-2&tab=overview
2. the pdfs folder: https://s3.console.aws.amazon.com/s3/buckets/datalabs-data/policy_tool_tests/pdfs/?region=us-east-2&tab=overview
3. the new pdf metadata csv: https://s3.console.aws.amazon.com/s3/object/datalabs-data/policy_tool_tests/pdfs_providers.csv?region=us-east-2&tab=overview

This PR outputs new things for evaluation 1, mainly a breakdown of the results per provider (msf, nice...). This is all done in the `metrics_by_provider` function, but there are a few other changes since we now need to input a new file (`pdfs_providers.csv`) which gives us the hash-provider links for each pdf (the metadata of which organisation each pdf is from).

Note: when I was making the evulation data I thought I may as well save the endnotes sections seeing as they do come up quite regularly and it wasn't any extra effort. But currently we don't actually scrape endnotes, so I can leave this out if preferred (although I think we should scrape this section eventually).

These new metrics are added to the output file, and currently look like:

```
Metrics by provider
                                              msf    nice  unicef  who_iris
Number of pdfs included                    15.000  17.000  31.000    32.000
Number of pdfs with sections text           7.000   5.000   9.000     5.000
Proportion of pdfs with sections text       0.467   0.294   0.290     0.156
F1 score for all sections included          0.911   0.941   0.914     0.979
Number of pdfs with a bibliograph section   1.000   0.000   0.000     1.000
Number of pdfs with a endnotes section      2.000   0.000   4.000     0.000
Number of pdfs with a reference section     4.000   5.000   5.000     4.000
Proportion with a bibliograph section       0.067   0.000   0.000     0.031
Proportion with a endnotes section          0.133   0.000   0.129     0.000
Proportion with a reference section         0.267   0.294   0.161     0.125
F1 score for the bibliograph section        0.933   1.000   1.000     0.969
F1 score for the endnotes section           0.933   1.000   1.000     1.000
F1 score for the reference section          0.867   0.824   0.742     0.969
```
And since this has the new data for evaluation 1 and 2, we now have real results for them:
```
-----Information about evaluation 1:-----

Score
0.94

F1-score
0.94

Metrics by provider
                                              msf    nice  unicef  who_iris
Number of pdfs included                    15.000  17.000  31.000    32.000
Number of pdfs with sections text           7.000   5.000   9.000     5.000
Proportion of pdfs with sections text       0.467   0.294   0.290     0.156
F1 score for all sections included          0.911   0.941   0.914     0.979
Number of pdfs with a bibliograph section   1.000   0.000   0.000     1.000
Number of pdfs with a endnotes section      2.000   0.000   4.000     0.000
Number of pdfs with a reference section     4.000   5.000   5.000     4.000
Proportion with a bibliograph section       0.067   0.000   0.000     0.031
Proportion with a endnotes section          0.133   0.000   0.129     0.000
Proportion with a reference section         0.267   0.294   0.161     0.125
F1 score for the bibliograph section        0.933   1.000   1.000     0.969
F1 score for the endnotes section           0.933   1.000   1.000     1.000
F1 score for the reference section          0.867   0.824   0.742     0.969

Number of unique pdfs
95

Number of pdfs with a section text
26

Classification report
              precision    recall  f1-score   support

       False       0.97      0.96      0.97       259
        True       0.66      0.73      0.69        26

   micro avg       0.94      0.94      0.94       285
   macro avg       0.81      0.85      0.83       285
weighted avg       0.94      0.94      0.94       285


Confusion matrix
                Predicted True  Predicted False
Actually True               19                7
Actually False              10              249

Number of unique pdfs with a endnotes section (actual)
6

Classification report for the endnotes section
              precision    recall  f1-score   support

       False       0.99      1.00      0.99        89
        True       1.00      0.83      0.91         6

   micro avg       0.99      0.99      0.99        95
   macro avg       0.99      0.92      0.95        95
weighted avg       0.99      0.99      0.99        95


Confusion matrix for the endnotes section
                Predicted True  Predicted False
Actually True                5                1
Actually False               0               89

Number of unique pdfs with a reference section (actual)
18

Classification report for the reference section
              precision    recall  f1-score   support

       False       0.94      0.87      0.91        77
        True       0.58      0.78      0.67        18

   micro avg       0.85      0.85      0.85        95
   macro avg       0.76      0.82      0.79        95
weighted avg       0.88      0.85      0.86        95


Confusion matrix for the reference section
                Predicted True  Predicted False
Actually True               14                4
Actually False              10               67

Number of unique pdfs with a bibliograph section (actual)
2

Classification report for the bibliograph section
              precision    recall  f1-score   support

       False       0.98      1.00      0.99        93
        True       0.00      0.00      0.00         2

   micro avg       0.98      0.98      0.98        95
   macro avg       0.49      0.50      0.49        95
weighted avg       0.96      0.98      0.97        95


Confusion matrix for the bibliograph section
                Predicted True  Predicted False
Actually True                0                2
Actually False               0               93

-----Information about evaluation 2:-----

Score
0.0

Mean normalised Levenshtein distance
0.6495045095526315

Strict accuracy (micro)
0.0

Lenient accuracy (micro)
0.2692307692307692

Mean normalised Levenshtein distance for the endnotes section
0.5239221133333984

Strict accuracy for the endnotes section
0.0

Lenient accuracy for the endnotes section
0.3333333333333333

Mean normalised Levenshtein distance for the reference section
0.6524213649093351

Strict accuracy for the reference section
0.0

Lenient accuracy for the reference section
0.2777777777777778

Mean normalised Levenshtein distance for the bibliograph section
1.0

Strict accuracy for the bibliograph section
0.0

Lenient accuracy for the bibliograph section
0.0

```