### PR TITLE
[WIP] Replace split section with IOBE model

### DIFF
--- a/policytool/refparse/README.md
+++ b/policytool/refparse/README.md
@@ -1,6 +1,6 @@
 # Wellcome Reference Parser
 
-Wellcome Reach's reference parser uses a home trained model to identify
+Wellcome Reach's reference parser uses home trained models to identify
 components from a set of scraped reference sections.
 
 ## How to use it
@@ -15,10 +15,11 @@ python ./refparse.py \
     --scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
     --references-file "file://./references_folder/references_file.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
+    --splitter-model-file "s3://datalabs-data/reference_splitter_models/line_iobe_pipeline_20190502.dll" \
     --output-url "file://./tmp/parser-output/output_folder_name"
 ```
 
-If the `scraper_file`, `references_file`, `model_file`, arguments are to
+If the `scraper_file`, `references_file`, `model_file` and `splitter_model_file`, arguments are to
 S3 locations then make sure these start with `s3://`, otherwise file
 names are assumed to be locally stored. If the `output_url` argument is
 to a local location, then make sure it begins with `file://`, otherwise
@@ -54,6 +55,7 @@ otherwise default values will be given:
 python ./parse_latest.py msf \
     --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
+    --splitter-model-file "s3://datalabs-data/reference_splitter_models/line_iobe_pipeline_20190502.dll" \
     --output-url "file://./tmp/parser-output/output_folder_name"
 ```
 

--- a/policytool/refparse/algo_evaluation/evaluate_settings.py
+++ b/policytool/refparse/algo_evaluation/evaluate_settings.py
@@ -15,6 +15,9 @@ class TestSettings(BaseSettings):
     SPLIT_SECTION_SIMILARITY_THRESHOLD = 40
     NUM_REFS_FILE_NAME = "split_section_test_data.csv"
     NUM_REFS_TEXT_FOLDER_NAME = "scraped_references_sections"
+    SPLIT_MODEL_FILE_TYPE = 'dill'
+    SPLIT_MODEL_FILE_PREFIX = './reference_splitter_models/'
+    SPLIT_MODEL_FILE_NAME = 'line_iobe_pipeline_20190502.dll'
 
     # Variables for parse evaluation data
     LEVENSHTEIN_DIST_PARSE_THRESHOLD = 0.3

--- a/policytool/refparse/algo_evaluation/evaluate_split_section.py
+++ b/policytool/refparse/algo_evaluation/evaluate_split_section.py
@@ -60,7 +60,7 @@ def evaluate_metrics(actual_pred_num_references, threshold):
 
     return metrics
 
-def evaluate_split_section(evaluate_split_section_data, regex, threshold):
+def evaluate_split_section(evaluate_split_section_data, model, threshold):
     """
     Split the references sections with split_section
     and compare the findings with the ground truth
@@ -68,7 +68,7 @@ def evaluate_split_section(evaluate_split_section_data, regex, threshold):
 
     actual_pred_num_references = []
     for references_section in evaluate_split_section_data['Reference section']:
-        references = split_section(references_section, regex = regex)
+        references = split_section(references_section, model)
         actual_pred_num_references.append({
             "Predicted references" : references,
             "Predicted number of references" : len(references)

--- a/policytool/refparse/evaluate_algo.py
+++ b/policytool/refparse/evaluate_algo.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from urllib.parse import urlparse
 from collections import defaultdict
 
+import numpy as np # Need for model pipelines
+
 from utils import FileManager
 from algo_evaluation.evaluate_settings import settings
 from algo_evaluation.evaluate_find_section import evaluate_find_section
@@ -150,6 +152,13 @@ if __name__ == '__main__':
         settings.MODEL_FILE_TYPE
     )
 
+    # Load the latest splitter model
+    splitter_model = fm.get_file(
+        settings.SPLIT_MODEL_FILE_NAME,
+        settings.SPLIT_MODEL_FILE_PREFIX,
+        settings.SPLIT_MODEL_FILE_TYPE
+    )
+
     # ==== Get the evaluation metrics ====
     logger.info('\nStarting the evaluations...\n')
 
@@ -163,7 +172,7 @@ if __name__ == '__main__':
     logger.info('[+] Running evaluation 3')
     eval3_scores = evaluate_split_section(
         evaluate_split_section_data,
-        settings.ORGANISATION_REGEX,
+        splitter_model,
         settings.SPLIT_SECTION_SIMILARITY_THRESHOLD
         )
 

--- a/policytool/refparse/settings.py
+++ b/policytool/refparse/settings.py
@@ -25,7 +25,8 @@ class BaseSettings:
     MODEL_DIR = "s3://{}/reference_parser_models".format(BUCKET)
     CLASSIFIER_FILENAME = "reference_parser_pipeline.pkl"
 
-    ORGANISATION_REGEX = "\\n[\d\.\s\\n]+(?=[A-Z])"
+    SPLIT_MODEL_DIR = "s3://{}/reference_splitter_models".format(BUCKET)
+    SPLITTER_FILENAME = "line_iobe_pipeline_20190502.dll"
 
     MIN_CHAR_LIMIT = 20
     HARD_TEXT_MIN_CHAR_LIMIT = 40
@@ -68,6 +69,7 @@ class LocalSettings(BaseSettings):
     SCRAPER_RESULTS_DIR = "scraper-results"
 
     MODEL_DIR = "reference_parser_models"
+    SPLIT_MODEL_DIR = "reference_splitter_models"
 
     OUTPUT_URL = "postgresql+psycopg2://{user}:{passw}@{host}:{port}/{db}".format(
           user=RDS_USERNAME,

--- a/policytool/refparse/tests/test_split.py
+++ b/policytool/refparse/tests/test_split.py
@@ -1,17 +1,24 @@
 import unittest
 
+import dill
+import os
+
 from policytool.refparse.utils import split_section
 from policytool.refparse.refparse import SectionedDocument
 
+MODELS_DIR = os.path.join(os.path.dirname(__file__), '..', 'reference_splitter_models')
+
+with open(os.path.join(MODELS_DIR, "line_iobe_pipeline_20190502.dll"), "rb") as f:
+    model = dill.load(f)
 
 class TestSplit(unittest.TestCase):
 
     def test_empty_sections(self):
-        references = split_section("")
+        references = split_section("", model)
         self.assertEqual(references, [], "Should be []")
 
     def test_oneline_section(self):
-        references = split_section("This is one line")
+        references = split_section("This is one line", model)
         self.assertEqual(
             references,
             ["This is one line"],
@@ -19,12 +26,13 @@ class TestSplit(unittest.TestCase):
         )
 
     def test_empty_lines_section(self):
-        references = split_section("\n\n\n")
+        references = split_section("\n\n\n", model)
         self.assertEqual(references, [], "Should be []")
 
     def test_normal_section(self):
         references = split_section(
-            "One reference\nTwo references\nThree references\n"
+            "One reference\nTwo references\nThree references\n",
+            model
         )
         self.assertEqual(
             references,

--- a/policytool/refparse/utils/file_manager.py
+++ b/policytool/refparse/utils/file_manager.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import os
 import pickle
+import dill
 import tempfile
 import json
 from .s3 import S3
 from policytool.refparse.settings import settings
-
 
 SCRAPING_COLUMNS = ('title', 'hash', 'sections', 'uri')
 
@@ -22,6 +22,7 @@ class FileManager():
             'csv': self.load_csv_file,
             'json': self.load_json_file,
             'pickle': self.load_pickle_file,
+            'dill': self.load_dill_file
         }
 
     def to_row(self, line, lineno):
@@ -106,3 +107,10 @@ class FileManager():
         """
         unpickled_file = pickle.loads(file_content.read())
         return unpickled_file
+
+    def load_dill_file(self, file_content):
+        """Load a dill file from a given path and file name and returns the
+        unpickled file.
+        """
+        loaded_dill_file = dill.load(file_content)
+        return loaded_dill_file

--- a/policytool/refparse/utils/split.py
+++ b/policytool/refparse/utils/split.py
@@ -1,35 +1,25 @@
 # -*- coding: utf-8 -*-
 
+import dill
 import re
 
+from sklearn.pipeline import Pipeline
 
-def split_section(references_section, regex="\n"):
-    """Converts the unstructured text into reference components
-    Input:
-    - a References section string
-    Output:
-    - A list of references data which come into a dict with keys
-        about the reference string, reference id, document uri and
-        document id
-    Nomenclature:
-    Document > References
-    """
-    references = re.split(regex, references_section)
-    # Remove any row with less than 10 characters in
-    # (these can't be references)
-    references = [r for r in references if len(r) > 10]
-    # delete '-\n', convert \n to spaces, convert â€™ to ', convert â€“ to -
-    references = [
-        reference.replace(
-            "-\n", ""
-        ).replace(
-            "\n", " "
-        ).replace(
-            "â€™", "'"
-        ).replace(
-            "â€“", "-"
-        )
-        for reference in references
-    ]
+def split_section(references_section, model):
+
+    lines = references_section.split('\n')
+
+    line_beginnings = [m.start() for m in re.finditer(r"\n", references_section)]
+    if references_section[0] != "\n":
+        line_beginnings = [0] + line_beginnings
+
+    predict_tags = model.predict(lines)
+    prob_tags = [p.max() for p in model.predict_proba(lines)]
+
+    # Cut up references_section at the line beginning of a line predicted to be a B
+    cut_here = [wb for (wb, t, p) in zip(line_beginnings, predict_tags, prob_tags) if t == "B"]
+
+    # Cut references_section at each index in cut_here:
+    references = [references_section[i:j] for i,j in zip(cut_here, cut_here[1:] + [None])]
 
     return references


### PR DESCRIPTION
# Description

`split_section` used to use a regex to split sections, but now it has been updated to use a trained IOBE model (see the line IOBE model [here](https://github.com/wellcometrust/datalabs/tree/master/modelling/policy/reference-splitter)).

This addition requires several changes to:
- 3 `algo_evaluation` files (`evaluate_settings`, `evaluate_split_section`,  and `evaluate_algo`) : use the model not the regex to evaluate split section, includes loading the model.
- `README`, `refparse` and `settings` : including the splitter model file path as an argument to refparse, loading the model, including the file path for it as an argument
- `test_split` : loading the model and inc the model arguments (previously just used the default regex in the test)
- `file_manager` : a new function to load dill files.
- `split` : remove the regex splitter and give the model splitter (the same as [this](https://github.com/wellcometrust/datalabs/blob/master/modelling/policy/reference-splitter/src/predict_iobe_line_splitter.py) expect for not having a choice of where to split)

Note:
If you don't have `import numpy as np` when you load the model it complains due to some of the features in the dill file needing numpy. The complaint is:
```
  File "/Users/gallaghe/Code/policytool/policytool/refparse/algo_evaluation/evaluate_split_section.py", line 71, in evaluate_split_section
    references = split_section(references_section, model)
  File "/Users/gallaghe/Code/policytool/policytool/refparse/utils/split.py", line 16, in split_section
    predict_tags = model.predict(lines)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/utils/metaestimators.py", line 118, in <lambda>
    out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/pipeline.py", line 331, in predict
    Xt = transform.transform(Xt)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/pipeline.py", line 822, in transform
    for name, trans, weight in self._iter())
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/parallel.py", line 917, in __call__
    if self.dispatch_one_batch(iterator):
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/parallel.py", line 759, in dispatch_one_batch
    self._dispatch(tasks)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/parallel.py", line 716, in _dispatch
    job = self._backend.apply_async(batch, callback=cb)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/_parallel_backends.py", line 182, in apply_async
    result = ImmediateResult(func)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/_parallel_backends.py", line 549, in __init__
    self.results = batch()
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/parallel.py", line 225, in __call__
    for func, args, kwargs in self.items]
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/externals/joblib/parallel.py", line 225, in <listcomp>
    for func, args, kwargs in self.items]
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/pipeline.py", line 605, in _transform_one
    res = transformer.transform(X)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/preprocessing/_function_transformer.py", line 160, in transform
    return self._transform(X, y=y, func=self.func, kw_args=self.kw_args)
  File "/Users/gallaghe/Code/policytool/build/virtualenv/lib/python3.7/site-packages/sklearn/preprocessing/_function_transformer.py", line 201, in _transform
    **(kw_args if kw_args else {}))
  File "train_iobe_line_model.py", line 34, in get_length
NameError: name 'np' is not defined
```

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature
- [x] :memo: Documentation update

# How Has This Been Tested?

The unittests don't work (as in don't even run). This is because of the `NameError: name 'np' is not defined` issue, and despite experimenting with adding `import numpy as np` all over the place the issue still occurs. I will chat to someone about this.

The new code does work however when I evaluate `split_sections` in `evaluate_algo`, and I get the same results as in 'Test Metric of Current Model on Policy Test Data' in [here](https://github.com/wellcometrust/datalabs/blob/master/modelling/policy/reference-splitter/docs/accuracy.md#test-metric-of-current-model-on-policy-test-data)

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
