### PR TITLE
Fix how the pdf parser find sections

### DIFF
--- a/policytool/pdf_parser/tools/extraction.py
+++ b/policytool/pdf_parser/tools/extraction.py
@@ -10,7 +10,7 @@ def _find_elements(pdf_file, keyword):
     titles_font_size = 0
     list_fonts = pdf_file.get_font_size_list()
     max_fonts_name = ''
-    regex = r''.join([r'(^|[\W]+)', keyword, r's?(?=[\W]+|$)'])
+    regex = r''.join([r'(^|[\W]+)', keyword, r'[a-z]*(?=[\W]+|$)'])
 
     if not list_fonts:
         return titles

--- a/policytool/resources/section_keywords.txt
+++ b/policytool/resources/section_keywords.txt
@@ -1,2 +1,3 @@
 reference
 bibliograph
+endnote


### PR DESCRIPTION
# Description
- Fix #152 pdf parser regex, https://github.com/wellcometrust/policytool/issues/152
- Add 'endnote' to the list of section keywords to search for, this is backed up by having looked at a sample of pdfs and finding that endnote is more common than 'bibliograph' sections.

```
Provider                                      msf    nice  unicef  who_iris
Number of pdfs included                    15.000  17.000  31.000    32.000
Proportion with a bibliograph section       0.067   0.000   0.000     0.031
Proportion with a endnotes section          0.133   0.000   0.129     0.000
Proportion with a reference section         0.267   0.294   0.161     0.125
```
## Type of change
- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?
27 unittests ran OK

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
