### PR TITLE
Fix fuzzymatcher

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ Dockerfile
 build/*
 !build/web/static
 pull_request_template.md
+policytool/refparse/algo_evaluation/data_evaluate/*

--- a/policytool/refparse/algo_evaluation/evaluate_match_references.py
+++ b/policytool/refparse/algo_evaluation/evaluate_match_references.py
@@ -30,7 +30,7 @@ def predict_match_data(matcher, match_data):
     """
 
     predictions = []
-    for i, ref in match_data.iterrows():
+    for ref in match_data:
         matched_publications = matcher.match(ref)
         if matched_publications:
             predictions.append(matched_publications['Matched publication id'])
@@ -111,10 +111,13 @@ def evaluate_match_references(
         ~evaluation_references['uber_id'].isin(match_data_negative['uber_id'])
         ]
 
-    fuzzy_matcher = FuzzyMatcher(evaluation_references_without_negative, match_threshold, length_threshold)
+    fuzzy_matcher = FuzzyMatcher(
+        evaluation_references_without_negative, match_threshold, length_threshold)
 
     predictions = predict_match_data(
-        match_data=pd.concat([match_data_positive, match_data_negative]),
+        match_data=
+            match_data_positive.to_dict('records') +
+            match_data_negative.to_dict('records'),
         matcher=fuzzy_matcher
         )
     actual = match_data_positive['Reference id'].to_list()+[None]*sample_N

--- a/policytool/refparse/utils/fuzzy_match.py
+++ b/policytool/refparse/utils/fuzzy_match.py
@@ -32,7 +32,7 @@ class FuzzyMatcher:
         return retrieved_publications[:nb_results]
 
     def match(self, reference):
-        if reference.empty:
+        if not reference:
             return
         if len(reference['Title']) < self.title_length_threshold:
             return


### PR DESCRIPTION
I broke fuzzymatcher recently by thinking that the input to match was a dataframe, when actually it is a dict.

So in this PR:

- Fixing input to match evaluation to be a dict rather than a dataframe
- reversing the change in fuzzymatcher to not assume a dataframe
- ignoring the evluation data (which is quite large) for docker

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make docker-test`
`==================== 60 passed, 25 warnings in 4.19 seconds ====================`