### PR TITLE
Look for text in all the scraped section names, and uncapitalise key name

### DIFF
--- a/policytool/pdf_parser/main.py
+++ b/policytool/pdf_parser/main.py
@@ -111,10 +111,10 @@ def parse_pdf(pdf, words, titles, context, pdf_hash):
             # Add references and PDF name to JSON returned file
             # If no section matchs, leave the attribute undefined
             if section:
-                if section_dict.get(title.title()):
-                    section_dict[title.title()].append(section)
+                if section_dict.get(title):
+                    section_dict[title].append(section)
                 else:
-                    section_dict[title.title()] = [section]
+                    section_dict[title] = [section]
 
     return {
         'file_hash': pdf_hash,

--- a/policytool/refparse/refparse.py
+++ b/policytool/refparse/refparse.py
@@ -50,16 +50,17 @@ def transform_scraper_file(scraper_data):
     for _, document in scraper_data.iterrows():
         if document["sections"]:
             try:
-                sections = document['sections']['Reference']
+                sections = document['sections']
             except KeyError:
                 return
-            assert isinstance(sections, list)
-            for section in sections:
-                yield SectionedDocument(
-                    section,
-                    None, # TODO: use document['uri'] after fixing scrape
-                    document['file_hash']
-                )
+            for section_list in sections.values():
+                assert isinstance(section_list, list)
+                for section in section_list:
+                    yield SectionedDocument(
+                        section,
+                        None, # TODO: use document['uri'] after fixing scrape
+                        document['file_hash']
+                    )
 
 def transform_structured_references(
         splitted_references, structured_references,


### PR DESCRIPTION
# Description

The old JSON format for the sections was:

`"sections":{"Reference": ['....'], "Bibliograph": ['....'], "Endnote": ['....']}`
where the keys are chosen based on what is in https://github.com/wellcometrust/policytool/blob/master/policytool/resources/section_keywords.txt

This PR fixes the problem where we were only looking for the 'Reference' section text (nothing else, i.e. bibliograph and endnote).

In this PR:
- fix pdf parser main to not capitalise dictionary keys - fixes issue #195 https://github.com/wellcometrust/policytool/issues/195 i.e. "sections":{"reference": ['....'], "bibliograph": ['....'], "endnote": ['....']}
- make section processing in refparse more generic to whatever section titles we have chosen to scrape (rather than only 'Reference')

## Type of change

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?
```
make docker-test
==================== 60 passed, 24 warnings in 3.99 seconds ====================
```

