### PR TITLE
policytool: make airflow scrapy tasks fail

### DIFF
--- a/policytool/scraper/wsf_scraping/file_system.py
+++ b/policytool/scraper/wsf_scraping/file_system.py
@@ -62,8 +62,7 @@ class FileSystem(ABC):
 
 class S3FileSystem(FileSystem):
     """
-    Complicated wrapper for writing things to S3. To be
-    removed/refactored.
+    (Blocking!) wrapper for writing things to S3.
     """
     def __init__(self, path, organisation, bucket):
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Description

Issue: https://github.com/wellcometrust/policytool/issues/192

While testing SSO credentials it became clear that scrapes are
running "to completion" even when the pipeline fails to complete,
or when items failed to be saved. Fix this by adding Scrapy signal
handlers to our airflow task, and by firing an additional signal
if we failed to write the final manifest file at the end of the
pipeline.

Other changes:

* Fix duplicate (and verbose -- boto debug logs were getting thrown in)
  logging by making our Crawler not add a root handler.
* Log scrapy settings on a single line; it was super long otherwise.
* Report exceptions in our blocking thread to Sentry, since
  they won't show up in the Twisted error log.
* Note that our item pipeline's uploader is blocking (!).

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
make test
```

And by adding `raise  Exception` to parts of the pipeline / feed storage, then running, given the docker-compose env is up:

```
./docker_exec.sh airflow test test_dag Spider.nice 2019-07-31
```

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
