### PR TITLE
Import on execute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION := latest
 # policytool/web
 #
 
-WEB_BUILD_IMAGE := uk.ac.wellcome/policytool-web-build
+WEB_BUILD_IMAGE := policytool-web-build
 WEB_BUILD_SOURCES := \
 	policytool/web/static/style.css \
 	policytool/web/gulpfile.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
   # and update the web image to serve static from build/static
   # by either an env or complicated volumes
   gulp-watch:
-    image: uk.ac.wellcome/policytool-web-build:latest
+    image: policytool-web-build:latest
     command:
       - gulp
       - watch

--- a/policytool/airflow/safe_import.py
+++ b/policytool/airflow/safe_import.py
@@ -1,0 +1,59 @@
+"""
+Prevents multiple threads from trying to import at the same time and
+hitting an import lock. Implemented because airflow's web server
+regularly re-imports all DAGs and all tasks therein -- and
+unfortunately, our tasks import so many dependencies that reloading them
+takes enough time (by some random distribution) that the Airflow times
+out imports, resulting in an endless stream of sentry reports from
+within gunicorn.
+
+So, we've moved "slow" imports, especially those pulling in ML libraries
+such as scipy or even pandas, into the execute() method of our tasks.
+
+This is almost always something you should NEVER do, because imports can
+only be trusted not to lock if they're done from the main thread and on
+module load.  (And an import lock in Python tends not to (or never?)
+resolve itself.) But, not much choice, at least for now.  And, it turns
+out that in our execution model, the celery executor spawns subprocesses
+to run each task. So, we shouldn't ever have an issue.
+
+Hope isn't a strategy, though. So, here's a context manager to use, so
+that we'll know if we were going to hit an import lock.
+
+Sample usage::
+
+    @report_exception
+    def execute(self):
+        with safe_import:
+            from policytool.rainbowpony import pony_ai
+
+        # do things with pony_ai here.
+
+"""
+
+from contextlib import contextmanager
+from threading import Lock
+
+# Not a re-entrant lock b/c we believe imports of this sort should
+# only happen once from the calling thread.
+SAFE_IMPORT_LOCK = Lock()
+
+@contextmanager
+def safe_import():
+    """
+    Context manager for ensuring that only one thread is importing
+    at a time. If two threads enter this context, the second will fail
+    with an exception so that we can't get caught in an import lock.
+    """
+    acquired = SAFE_IMPORT_LOCK.acquire(blocking=False)
+    try:
+        if not acquired:
+            # NB: we could, instead, just wait here. But the invariant
+            # we're expecting is that, thanks to how the celery executor
+            # works, only one call to execute() should happen at a time,
+            # because only one thread should ever be running.
+            raise Exception('Multiple imports attempted at once!')
+        yield
+    finally:
+        if acquired:
+            SAFE_IMPORT_LOCK.release()

--- a/policytool/airflow/tasks/es_index_publications.py
+++ b/policytool/airflow/tasks/es_index_publications.py
@@ -9,7 +9,7 @@ from airflow.utils.decorators import apply_defaults
 from elasticsearch import Elasticsearch
 
 from policytool.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
-from policytool.elastic.import_epmc_metadata import import_into_elasticsearch,
+from policytool.elastic.import_epmc_metadata import import_into_elasticsearch
 from policytool.elastic.import_epmc_metadata import clean_es
 
 

--- a/policytool/airflow/tasks/exact_match_refs_operator.py
+++ b/policytool/airflow/tasks/exact_match_refs_operator.py
@@ -14,7 +14,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 from policytool.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
-from policytool.refparse.refparse import exact_match_publication
+from policytool.airflow.safe_import import safe_import
 from policytool.sentry import report_exception
 
 logger = logging.getLogger(__name__)
@@ -91,6 +91,9 @@ class ExactMatchRefsOperator(BaseOperator):
 
     @report_exception
     def execute(self, context):
+        with safe_import():
+            from policytool.refparse.refparse import exact_match_publication
+
         publications_path = 's3://{path}'.format(
             path=self.publications_path,
         )

--- a/policytool/airflow/tasks/extract_refs_operator.py
+++ b/policytool/airflow/tasks/extract_refs_operator.py
@@ -10,8 +10,8 @@ import gzip
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from policytool.refparse.refparse import yield_structured_references
 from policytool.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
+from policytool.airflow.safe_import import safe_import
 from policytool.sentry import report_exception
 
 
@@ -46,6 +46,9 @@ class ExtractRefsOperator(BaseOperator):
 
     @report_exception
     def execute(self, context):
+        with safe_import():
+            from policytool.refparse.refparse import yield_structured_references
+
         pool_map = map
         s3 = WellcomeS3Hook(aws_conn_id=self.aws_conn_id)
 

--- a/policytool/airflow/tasks/fuzzy_match_refs_operator.py
+++ b/policytool/airflow/tasks/fuzzy_match_refs_operator.py
@@ -14,7 +14,7 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 from policytool.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
-from policytool.refparse.refparse import fuzzy_match_reference
+from policytool.airflow.safe_import import safe_import
 from policytool.sentry import report_exception
 
 logger = logging.getLogger(__name__)
@@ -101,6 +101,9 @@ class FuzzyMatchRefsOperator(BaseOperator):
 
     @report_exception
     def execute(self, context):
+        with safe_import():
+            from policytool.refparse.refparse import fuzzy_match_reference
+
         structured_references_path = 's3://{path}'.format(
             path=self.structured_references_path,
         )

--- a/policytool/airflow/tasks/parse_pdf_operator.py
+++ b/policytool/airflow/tasks/parse_pdf_operator.py
@@ -7,7 +7,7 @@ import logging
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
-from policytool.pdf_parser.main import parse_all_pdf
+from policytool.airflow.safe_import import safe_import
 from policytool.sentry import report_exception
 
 
@@ -36,6 +36,9 @@ class ParsePdfOperator(BaseOperator):
 
     @report_exception
     def execute(self, context):
+        with safe_import():
+            from policytool.pdf_parser.main import parse_all_pdf
+
         os.environ.setdefault(
             'SCRAPY_SETTINGS_MODULE',
             'scraper.wsf_scraping.settings'

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ idna==2.8
 incremental==17.5.0
 iso8601==0.1.12
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.10.1
 jmespath==0.9.4
 joblib==0.13.2
 json-merge-patch==0.2


### PR DESCRIPTION
# Description

airflow: only import ML libs on execute

Resolve (we hope) a persistent issue and cause of incidents:
import time for DAGs takes an unreliably bounded amount of time,
resulting in Airflow's web UI raising an AirflowTaskTimeout
(which isn't really for a task at all...but oh well). Key changes:

* Add a library for safely importing modules from within Airflow
  task execute() methods.
* Move heavy imports for all ML tasks into their execute() methods.

Also fix a typo in airflow.tasks.es_index_publications.

https://github.com/wellcometrust/policytool/issues/194
https://github.com/wellcometrust/datalabs-infra/issues/203
https://github.com/wellcometrust/datalabs-infra/issues/209

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

* `make docker-test`.
* Ran test DAG locally.
* Manually verified exceptions raise by running thread w/time.sleep() and then trying to enter the `safe_import()` context a second time.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
