### PR TITLE
Fix image name in web's docker_run file

### DIFF
--- a/policytool/web/bin/docker_run.sh
+++ b/policytool/web/bin/docker_run.sh
@@ -13,5 +13,5 @@ docker run \
     -v $BUILD_DIR/:/build/web/static \
     -v $DIR/gulpfile.js:/src/gulpfile.js \
     -v $DIR/static:/src/static \
-    uk.ac.wellcome/policytool-web-build:latest \
+    policytool-web-build:latest \
     $*


### PR DESCRIPTION
# Description

This PR aims to fix the build error that occured on build policytool:af97e75c-7be0-4dcf-bcae-2467c8ee0cdd

by changing the image name in the docker_run file of the web project.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
make test
make docker-test

make docker-build
make web-image-build
```