### PR TITLE
Add a file removal in the scraper's pipeline

### DIFF
--- a/policytool/scraper/wsf_scraping/pipelines.py
+++ b/policytool/scraper/wsf_scraping/pipelines.py
@@ -101,4 +101,9 @@ class WsfScrapingPipeline(object):
                 'This pdf is already in the manifest file.'
             )
 
+        # Remove the file to save storage
+        os.unlink(
+            os.path.join('/tmp', item['pdf'])
+        )
+
         return item


### PR DESCRIPTION
# Description

Current version of the scrapers on staging runs out of disk on full runs. At the moment, we're not removing downloaded pdf tempfiles dureing the process. This PR adds a `os.unlink` command to try to remedy to the disk shortage by removing already uploaded pdf files.

Note that this fix may not completly fix the disk issue.

See https://github.com/wellcometrust/datalabs-infra/issues/232 for more details about the issue.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make test`
`make docker-test`
Local runs on Mac OS 10.14.6, with Docker @ 2CPU/10.5GiB RAM