### PR TITLE
Add some fields to the scraper's manifest

### DIFF
--- a/policytool/pdf_parser/main.py
+++ b/policytool/pdf_parser/main.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+MANIFEST_IGNORE_FIELDS = [
+    'start-time',
+    'stop-time',
+    'organisation',
+]
+
+
 def default_resources_dir():
     """ Returns path to resources/ within our repo. """
     return os.path.join(
@@ -231,21 +238,25 @@ def parse_all_pdf(input_url, output_url, organisation, context,
     parsed_items = []
     manifest = file_system.get_manifest()
     for directory in manifest:
-        for item in manifest[directory]:
-            pdf = file_system.get(item)
+        if directory in MANIFEST_IGNORE_FIELDS:
+            continue
+        else:
+            for item in manifest[directory]:
+                logger.info(item + '  --- ' + directory)
+                pdf = file_system.get(item)
 
-            # Download PDF file to /tmp
-            with tempfile.NamedTemporaryFile(delete=False) as tf:
-                tf.write(pdf.read())
-                tf.seek(0)
-                item = parse_pdf(
-                    tf.name,
-                    words,
-                    titles,
-                    context,
-                    item,
-                )
-            parsed_items.append(item)
+                # Download PDF file to /tmp
+                with tempfile.NamedTemporaryFile(delete=False) as tf:
+                    tf.write(pdf.read())
+                    tf.seek(0)
+                    item = parse_pdf(
+                        tf.name,
+                        words,
+                        titles,
+                        context,
+                        item,
+                    )
+                parsed_items.append(item)
 
     write_to_file(output_url, parsed_items, organisation)
 

--- a/policytool/pdf_parser/main.py
+++ b/policytool/pdf_parser/main.py
@@ -21,13 +21,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-MANIFEST_IGNORE_FIELDS = [
-    'start-time',
-    'stop-time',
-    'organisation',
-]
-
-
 def default_resources_dir():
     """ Returns path to resources/ within our repo. """
     return os.path.join(
@@ -236,27 +229,24 @@ def parse_all_pdf(input_url, output_url, organisation, context,
         file_system = LocalFileSystem(output_url, organisation)
 
     parsed_items = []
-    manifest = file_system.get_manifest()
-    for directory in manifest:
-        if directory in MANIFEST_IGNORE_FIELDS:
-            continue
-        else:
-            for item in manifest[directory]:
-                logger.info(item + '  --- ' + directory)
-                pdf = file_system.get(item)
+    content = file_system.get_manifest().get('content', [])
+    for directory in content:
+        for item in content[directory]:
+            logger.info(item + '  --- ' + directory)
+            pdf = file_system.get(item)
 
-                # Download PDF file to /tmp
-                with tempfile.NamedTemporaryFile(delete=False) as tf:
-                    tf.write(pdf.read())
-                    tf.seek(0)
-                    item = parse_pdf(
-                        tf.name,
-                        words,
-                        titles,
-                        context,
-                        item,
-                    )
-                parsed_items.append(item)
+            # Download PDF file to /tmp
+            with tempfile.NamedTemporaryFile(delete=False) as tf:
+                tf.write(pdf.read())
+                tf.seek(0)
+                item = parse_pdf(
+                    tf.name,
+                    words,
+                    titles,
+                    context,
+                    item,
+                )
+            parsed_items.append(item)
 
     write_to_file(output_url, parsed_items, organisation)
 

--- a/policytool/scraper/wsf_scraping/file_system.py
+++ b/policytool/scraper/wsf_scraping/file_system.py
@@ -124,9 +124,9 @@ class S3FileSystem(FileSystem):
         metadata = {}
         metadata['organisation'] = self.organisation
         metadata['start-time'] = \
-            self.start_time.strftime("%Y-%m-%d, %H:%M:%S")
+            self.start_time.isoformat()
         metadata['stop-time'] = \
-            datetime.datetime.now().strftime("%Y-%m-%d, %H:%M:%S")
+            datetime.datetime.now().isoformat()
 
         data_file.seek(0)
 


### PR DESCRIPTION
# Description
Add's start-time, end-time and organisation fields to the manifest

Also ignore those fields in the pdf parser task.

## Type of change
- [x] :sparkles: New feature

# How Has This Been Tested?
Local tests
`make test`
`make docker-test`
