### PR TITLE
airflow: add fuzzy matcher back to DAG

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ x-airflow_env: &airflow-env
   # (in `core` because we must be in an existing section of the cfg)
   AIRFLOW__CORE__REACH_S3_PREFIX: "s3://datalabs-dev/reach-airflow" # No trailing /!
   AIRFLOW__CORE__OPENRESEARCH_S3_PREFIX: "s3://datalabs-dev/airflow" # No trailing /!
-  # AIRFLOW__CORE__DATALABS_ALTERYX_PREFIX: "s3://datalabs-staging/alteryx" # No trailing /!
+
+  # Comma delimited list of elasticsearch addresses/urls to use
+  AIRFLOW__CORE__ELASTICSEARCH_HOSTS: "elasticsearch:9200"
 
   # dev creds encryption key, cf.
   # https://airflow.readthedocs.io/en/stable/howto/secure-connections.html


### PR DESCRIPTION
# Description

* Configure ES hosts by environment variable
* Add FuzzyMatchRefsOperator to main & test DAGs
* Update FuzzyMatchRefsOperator to use the right ES index name

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [x] :sparkles: New feature

# How Has This Been Tested?

Test DAG runs successfully. As does:

```
make docker-test
```

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
