### PR TITLE
scraper: fix logic for deleting PDFs post scrape

### DIFF
--- a/policytool/scraper/wsf_scraping/pipelines.py
+++ b/policytool/scraper/wsf_scraping/pipelines.py
@@ -96,14 +96,8 @@ class WsfScrapingPipeline(object):
             )
             with open(item['pdf'], 'rb') as pdf:
                 self.storage.save(pdf, path, item['hash'] + '.pdf')
-        else:
-            raise DropItem(
-                'This pdf is already in the manifest file.'
-            )
 
         # Remove the file to save storage
-        os.unlink(
-            os.path.join('/tmp', item['pdf'])
-        )
+        os.unlink(item['pdf'])
 
         return item


### PR DESCRIPTION
# Description

The first attempt at fixing this failed because all files (up to point
of node disk pressure & pod eviction) were already present in the
manifest, and thus the unlink never occurred. Fix this by:

* no longer raising DropItem (we don't have any more steps in the
  pipeline anymore anyway), so that we always unlink.
* also using the correct path for deleting the file (item['pdf'] is
  an absolute path)

Issue: https://github.com/wellcometrust/policytool/issues/220

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make docker-test` (though this won't reach this code path...sadly)

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
