### PR TITLE
pdf_parser, airflow: fix memory & file leaks

### DIFF
--- a/policytool/airflow/tasks/parse_pdf_operator.py
+++ b/policytool/airflow/tasks/parse_pdf_operator.py
@@ -27,6 +27,8 @@ class ParsePdfOperator(BaseOperator):
         'src_s3_dir',
     )
 
+    KEYWORD_SEARCH_CONTEXT = 2
+
     @apply_defaults
     def __init__(self, organisation, src_s3_dir, dst_s3_key, *args, **kwargs):
         super(ParsePdfOperator, self).__init__(*args, **kwargs)
@@ -37,7 +39,7 @@ class ParsePdfOperator(BaseOperator):
     @report_exception
     def execute(self, context):
         with safe_import():
-            from policytool.pdf_parser.main import parse_all_pdf
+            import policytool.pdf_parser.main as pdf_parser_main
 
         os.environ.setdefault(
             'SCRAPY_SETTINGS_MODULE',
@@ -49,5 +51,8 @@ class ParsePdfOperator(BaseOperator):
             raise ValueError
 
         input_uri = 'manifest' + self.src_s3_dir
-        output_uri = 'manifest' + self.dst_s3_key
-        parse_all_pdf(input_uri, output_uri, self.organisation, 2)
+        pdf_parser_main.parse_all_pdf(
+            self.organisation,
+            input_uri,
+            self.dst_s3_key,
+        )


### PR DESCRIPTION
# Description

* Fix parse_all_pdf() so that it doesn't accumulate all text into memory
  before writing to disk.
* Fix parse_all_pdf() so that it deletes PDF files after parsing
* Update parse_all_pdf() so that it writes chunks from the network
  to tempfile instead of downloading all of it into memory at once.
* Fix parse_pdf_document() so that it takes a named tempfile and so
  that it uses a dedicated tempfile, so that we don't proliferate XML
  files when parse fails.
* Remove manifest from output URL (output is jsonl, not a scraper
  manifest).
* Fix CLI for policytool.pdf_parser.main & give example.
* Configure logging for CLI for policytool.pdf_parser.main.

Issue: https://github.com/wellcometrust/policytool/issues/224

## Type of change

Please delete options that are not relevantx

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
python -m policytool.pdf_parser.main \
    msf \
    manifests3://datalabs-staging/reach-airflow/output/policy/spider/msf/spider-msf \
    s3://datalabs-dev/pdf_parser_test_output.json.gz
```

```
make docker-test
```

And by running the PdfParser.msf from localdev Airflow using staging scrape as inputs.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
