### PR TITLE
pdf_parser: skip pdf2html outputs > 64MB

### DIFF
--- a/policytool/pdf_parser/main.py
+++ b/policytool/pdf_parser/main.py
@@ -91,12 +91,14 @@ def parse_pdf(pdf, words, titles, context, pdf_hash):
         item: A dict containing the pdf text, sections and keywords.
     """
     # Convert PDF content to text format
-    pdf_file, pdf_text = parse_pdf_document(pdf)
+    pdf_file, pdf_text, errors = parse_pdf_document(pdf)
     # If the PDF couldn't be converted, still remove the pdf file
     if not pdf_file:
-        logger.warning('The pdf couldn\'t be parsed {pdf_hash}'.format(
-            pdf_hash=pdf_hash,
-        ))
+        assert errors, 'Errors must be supplied if no parse'
+        logger.warning(
+            'parse_pdf: pdf_hash=%s errors=%s',
+            pdf_hash, ','.join(errors)
+        )
 
         # We still have to return something for the json to be complete.
         return {
@@ -104,6 +106,7 @@ def parse_pdf(pdf, words, titles, context, pdf_hash):
             'sections': None,
             'keywords': None,
             'text': None,
+            'errors': errors,
         }
 
     # Fetch references or other keyworded list

--- a/policytool/pdf_parser/tests/test_pdf_objects.py
+++ b/policytool/pdf_parser/tests/test_pdf_objects.py
@@ -58,7 +58,8 @@ class TestPdfObjects(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object, _ = parse_pdf_document(self.test_file)
+        self.pdf_file_object, _, errors = parse_pdf_document(self.test_file)
+        assert not errors
 
     def tearDown(self):
         self.test_file.close()

--- a/policytool/pdf_parser/tests/test_pdf_parser_tools.py
+++ b/policytool/pdf_parser/tests/test_pdf_parser_tools.py
@@ -9,7 +9,8 @@ class TestTools(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object, _ = parse_pdf_document(self.test_file)
+        self.pdf_file_object, _, errors = parse_pdf_document(self.test_file)
+        assert not errors
 
     def tearDown(self):
         self.test_file.close()


### PR DESCRIPTION
# Description

Some PDF files have caused our airflow worker to OOM. Remediate this
by skipping these files (which, on inspection of one at least, didn't
contain any useable data):

* Skip PDF files where pdf2html output is > 64MB
* Update parse_pdf_document() so it returns parse errors
* Include PDF parse errors in JSON output, so we can track how many
  parses fail and of what kind
* ~~Use LXML instead of BeautifulSoup for parsing HTML (faster, may be
  more memory efficient)~~

Issue: https://github.com/wellcometrust/policytool/issues/227

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
./docker_exec.sh airflow test policy ParsePdf.who_iris 2019-09-01
```

using a `docker-compose.yml` that pointed to `s3://datalabs-staging/`, and where the manifest was updated to only include files with hash prefix of `69`.

`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
