### PR TITLE
Fix gov scraping

### DIFF
--- a/policytool/scraper/tests/mock_sites/gov/1.html
+++ b/policytool/scraper/tests/mock_sites/gov/1.html
@@ -1,23 +1,83 @@
 <!DOCTYPE html>
-<head>
-    <title>Publications - GOV.UK</title>
+<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en">
+<!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <title>Policy papers and consultations - GOV.UK</title>
 </head>
 
-  <body class="website government">
+  <body class="">
 
-      <div class="filter-results js-filter-results" aria-live="polite">
-          <ol class="js-document-list document-list" data-module="track-click">
-      <li id="publication_915523" class="document-row">
-        <h3>
-          <a href="/government/publications/uk-ncp-steering-board-meeting-minutes-17-october-2018" data-category="navPublicationLinkClicked" data-action="1" data-label="/government/publications/uk-ncp-steering-board-meeting-minutes-17-october-2018" data-options='{"dimension28":"40","dimension29":"UK NCP Steering Board meeting minutes: 17 October 2018"}'>UK NCP Steering Board meeting minutes: 17 October 2018</a>
-        </h3>
-        <ul class="attributes">
-          <li><time class="public_timestamp" datetime="2019-02-06T15:01:47+00:00"> 6 February 2019</time></li>
-          <li class="organisations"><abbr title="Department for International Trade">DIT</abbr></li>
-          <li class="display-type">Transparency data</li>
-        </ul>
+  <div class="facet-tags" data-module="track-click">
+      <div class="facet-tags__group">
+          <div class="facet-tags__wrapper">
+            <p class="facet-tags__preposition">Of Type</p>
+            <div class="facet-tag">
+              <p class="facet-tag__text">Policy papers</p>
+              <button type="button" class="facet-tag__remove" aria-label="Remove filter Policy papers" data-module="remove-filter-link" data-track-label="Policy papers" data-facet="content_store_document_type" data-value="policy_papers" data-name="">✕</button>
+            </div>
+          </div>
+      </div>
+  </div>
+
+          </div>
+        </div>
+
+        <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
+
+        <div id="js-sort-options">
+            <div class="govuk-form-group">
+    <label for="order" class="result-region-header__sort-label govuk-label">Sort by</label>
+    <select class="js-order-results govuk-select" name="order" id="order" aria-controls="js-search-results-info" data-default-sort-option="updated-newest" data-relevance-sort-option="relevance" data-module="track-select-change">
+        <option value="most-viewed" data-track-category="dropDownClicked" data-track-action="clicked" data-track-label="Most viewed">Most viewed</option>
+        <option value="relevance" disabled data-track-category="dropDownClicked" data-track-action="clicked" data-track-label="Relevance">Relevance</option>
+        <option value="updated-newest" selected data-track-category="dropDownClicked" data-track-action="clicked" data-track-label="Updated (newest)">Updated (newest)</option>
+        <option value="updated-oldest" data-track-category="dropDownClicked" data-track-action="clicked" data-track-label="Updated (oldest)">Updated (oldest)</option>
+    </select>
+  </div>
+
+        </div>
+
+        <div id="js-results">
+            <div class="finder-results js-finder-results" data-module="track-click">
+        <ol class="gem-c-document-list gem-c-document-list--no-underline">
+
+      <li class="gem-c-document-list__item  ">
+        <a data-ecommerce-path="/government/publications/continuing-the-uks-trade-relationship-with-south-korea-parliamentary-report" data-ecommerce-content-id="aa69bee3-7cb1-409e-9dad-bb2c1d083208" data-ecommerce-row="1" data-track-category="navFinderLinkClicked" data-track-action="Policy papers and consultations.1" data-track-label="/government/publications/continuing-the-uks-trade-relationship-with-south-korea-parliamentary-report" data-track-options="{&quot;dimension28&quot;:20,&quot;dimension29&quot;:&quot;Continuing the UK's trade relationship with South Korea: parliamentary report&quot;}" class="gem-c-document-list__item-title  " href="/government/publications/continuing-the-uks-trade-relationship-with-south-korea-parliamentary-report">Continuing the UK's trade relationship with South Korea: parliamentary report</a>
+
+
+          <p class="gem-c-document-list__item-description">This report explains the government’s approach to maintaining continuity of the trade relationship between the UK and South Korea after Brexit.</p>
+
+          <ul class="gem-c-document-list__item-metadata">
+              <li class="gem-c-document-list__attribute">
+                  From: Department for International Trade
+              </li>
+              <li class="gem-c-document-list__attribute">
+                  Updated: <time datetime="2019-09-09">9 September 2019</time>
+              </li>
+          </ul>
+
       </li>
-  </ol>
+
+      <li class="gem-c-document-list__item  ">
+        <a data-ecommerce-path="/government/publications/investing-in-women-code" data-ecommerce-content-id="8e39770b-686e-4bb0-bb65-25bed937b5cb" data-ecommerce-row="1" data-track-category="navFinderLinkClicked" data-track-action="Policy papers and consultations.2" data-track-label="/government/publications/investing-in-women-code" data-track-options='{"dimension28":20,"dimension29":"Investing in Women Code"}' class="gem-c-document-list__item-title  " href="/government/publications/investing-in-women-code">Investing in Women Code</a>
+
+
+          <p class="gem-c-document-list__item-description">The Investing in Women Code is a commitment by financial services firms to improving female entrepreneurs’ access to tools, resources and finance.</p>
+
+          <ul class="gem-c-document-list__item-metadata">
+              <li class="gem-c-document-list__attribute">
+                  From: HM Treasury
+              </li>
+              <li class="gem-c-document-list__attribute">
+                  Updated: <time datetime="2019-09-09">9 September 2019</time>
+              </li>
+          </ul>
+
+      </li>
+    </ol>
+
+  </div>
 </div>
 </body>
 </html>

--- a/policytool/scraper/tests/mock_sites/gov/2.html
+++ b/policytool/scraper/tests/mock_sites/gov/2.html
@@ -1,24 +1,558 @@
 <!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en">
+<!--<![endif]-->
   <head>
-    <title lang="en">
-      UK NCP Steering Board meeting minutes: 17 October 2018 - GOV.UK
-  </title>
 </head>
 
   <body>
-  <h1 class="gem-c-title__text gem-c-title__text--long">
-    UK NCP Steering Board meeting minutes: 17 October 2018
-  </h1>
-    <div class="app-c-published-dates ">
-    Published 6 February 2019
+
+
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">Skip to main content</a>
+      </div>
+    </div>
+
+
+<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner">
+  <div class="gem-c-cookie-banner__wrapper govuk-width-container">
+    <p class="gem-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler.</p>
+    <div class="gem-c-cookie-banner__buttons">
+      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
+
+
+
+  <button class="gem-c-button govuk-button gem-c-button--secondary gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>
+
+
+      </div>
+      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
+
+
+
+  <a class="gem-c-button govuk-button gem-c-button--secondary gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>
+
+
+      </div>
+    </div>
+  </div>
+
+  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+    <p class="gem-c-cookie-banner__confirmation-message">
+      You’ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
+    </p>
+    <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
+  </div>
 </div>
+
+
+    <header role="banner" id="global-header" class=" with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" id="logo" class="content" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+              <img src="https://assets.publishing.service.gov.uk/static/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+            </a>
+          </div>
+            <a href="#search" class="search-toggle js-header-toggle">Search</a>
+  <form id="search" class="site-search" action="/search" method="get" role="search">
+    <div class="content">
+      <label for="site-search-text">Search</label>
+      <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+      <input class="submit" type="submit" value="Search">
+    </div>
+  </form>
+
+        </div>
+
+      <div class="header-proposition">
+  <div class="content">
+    <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+  <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation">
+  <ul id="proposition-links">
+    <li>
+      <a class="" href="/government/organisations">
+        Departments
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/world">
+        Worldwide
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/how-government-works">
+        How government works
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/get-involved">
+        Get involved
+      </a>
+    </li>
+    <li class="clear-child">
+      <a class="" href="/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&amp;amp;content_store_document_type%5B%5D=closed_consultations">
+        Consultations
+      </a>
+    </li>
+    <li>
+      <a class="" href="/search/research-and-statistics">
+        Statistics
+      </a>
+    </li>
+    <li>
+      <a class="" href="/news-and-communications">
+        News and communications
+      </a>
+    </li>
+  </ul>
+</nav>
+</div>
+</div>
+</div>
+    </header>
+
+      <div id="user-satisfaction-survey-container"></div>
+
+
+    <div id="global-header-bar"></div>
+
+        <!--[if gt IE 7]><!-->
+  <div id="global-bar" class="global-bar dont-print" data-module="global-bar">
+    <div class="global-bar-message-container">
+    <p class="global-bar-message">
+      <span class="global-bar-title">The United Kingdom is leaving the European Union on 31 October 2019.</span>
+      <a rel="external noreferrer" class="js-call-to-action" href="/brexit">Get ready for Brexit</a>
+    </p>
+    <a href="#hide-message" class="dismiss" role="button" aria-controls="global-bar">Hide message</a>
+    </div>
+  </div>
+  <!--<![endif]-->
+
+
+  <div id="wrapper" class="direction-ltr">
+
+
+
+<div class="gem-c-contextual-breadcrumbs">
+
+
+
+<div class="gem-c-breadcrumbs govuk-breadcrumbs " data-module="track-click">
+  <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item" aria-current="false">
+          <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" class="govuk-breadcrumbs__link" aria-current="false" href="/">Home</a>
+      </li>
+  </ol>
+</div>
+
+
+</div>
+
+
+    <main role="main" id="content" class="publication" lang="en">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="gem-c-title govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <p class="gem-c-title__context">
+      Policy paper
+    </p>
+  <h1 class="gem-c-title__text gem-c-title__text--long">
+    Prevention concordat for better mental health: consensus statement
+  </h1>
+</div>
+  </div>
+
+
+  <div class="govuk-grid-column-two-thirds">
+
+  <p class="gem-c-lead-paragraph ">
+    Describes the consensus statement of the prevention concordat for better mental health and lists the signatories.
+  </p>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="metadata-logo-wrapper">
+    <div class="govuk-grid-column-two-thirds metadata-column">
+        <div class="app-c-publisher-metadata" lang="en">
+    <div class="app-c-published-dates " lang="en">
+    Published 30 August 2017
+    <br>Last updated 9 September 2019
+      — <a href="#history" class="app-c-published-dates__history-link govuk-link">see all updates</a>
+</div>
+
+      <div class="app-c-publisher-metadata__other">
+        <dl data-module="track-click">
+            <dt class="app-c-publisher-metadata__term">
+              From:
+            </dt>
+            <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
+                <span class="app-c-publisher-metadata__definition-sentence">
+                  <a class="govuk-link" href="/government/organisations/public-health-england">Public Health England</a>
+                </span>
+            </dd>
+        </dl>
+      </div>
+  </div>
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+    </div>
+  </div>
+</div>
+
+
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-bottom-margin">
+
+    <div class="responsive-bottom-margin">
+       <h2 class="gem-c-heading  gem-c-heading--mobile-top-margin  " id="documents-title">Documents</h2>
+
+
+<div aria-labelledby="documents-title">
+
+<div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
+      <section class="attachment embedded" id="attachment_3647773">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" tabindex="-1" href="/government/publications/prevention-concordat-for-better-mental-health-consensus-statement/prevention-concordat-for-better-mental-health"><img alt="" src="/government/assets/pub-cover-html-b0465911e56983d98c70f0e25fba24bc206d37e8c83d4addf6421dcf6022c6cd.png"></a>
+  </div>
   <div class="attachment-details">
-    <h2 class="title"><a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/770271/Minutes_of_the_Steering_Board_meeting_for_the_UK_NCP_held_on_17_October_2018.pdf">UK NCP Steering Board meeting minutes: 17 October 2018</a></h2>
+    <h2 class="title"><a href="/government/publications/prevention-concordat-for-better-mental-health-consensus-statement/prevention-concordat-for-better-mental-health">Prevention concordat for better mental health</a></h2>
     <p class="metadata">
-        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">120KB</span>, <span class="page-length">4 pages</span>
+        <span class="type">HTML</span>
     </p>
 
 
   </div>
+</section>
+</div>
+
+</div>
+
+<h2 class="gem-c-heading  gem-c-heading--mobile-top-margin  " id="details-title">Details</h2>
+
+
+<div aria-labelledby="details-title">
+
+<div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
+      <div class="govspeak">
+<p>This document:</p>
+
+<ul>
+  <li>explains the prevention concordat for better mental health</li>
+  <li>describes the shared commitment of the organisations involved</li>
+  <li>provides a list of all signatory organisations</li>
+</ul>
+</div>
+</div>
+
+</div>
+
+    </div>
+<div class="govuk-grid-column-one-third">
+
+<div class="gem-c-contextual-sidebar">
+
+
+  <div class="gem-c-related-navigation">
+
+      <h2 id="related-nav-related_items-9de1db80" class="gem-c-related-navigation__main-heading" data-track-count="sidebarRelatedItemSection">
+        Related content
+      </h2>
+
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-9de1db80" data-module="gem-toggle">
+
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.1 Related content" data-track-label="/government/publications/prevention-concordat-for-better-mental-health-planning-resource" data-track-options='{"dimension28":"5","dimension29":"Prevention concordat for better mental health: planning resource"}' href="/government/publications/prevention-concordat-for-better-mental-health-planning-resource">Prevention concordat for better mental health: planning resource</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.2 Related content" data-track-label="/government/collections/prevention-concordat-for-better-mental-health" data-track-options='{"dimension28":"5","dimension29":"Prevention concordat for better mental health"}' href="/government/collections/prevention-concordat-for-better-mental-health">Prevention concordat for better mental health</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.3 Related content" data-track-label="/government/publications/mental-health-services-cost-effective-commissioning" data-track-options='{"dimension28":"5","dimension29":"Mental health services: cost-effective commissioning"}' href="/government/publications/mental-health-services-cost-effective-commissioning">Mental health services: cost-effective commissioning</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.4 Related content" data-track-label="/government/publications/stocktake-of-local-mental-health-prevention-planning-arrangements" data-track-options='{"dimension28":"5","dimension29":"Stocktake of local mental health prevention planning arrangements"}' href="/government/publications/stocktake-of-local-mental-health-prevention-planning-arrangements">Stocktake of local mental health prevention planning arrangements</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--inline  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.5 Related content" data-track-label="/government/publications/public-mental-health-leadership-and-workforce-development-framework" data-track-options='{"dimension28":"5","dimension29":"Public mental health leadership and workforce development framework"}' href="/government/publications/public-mental-health-leadership-and-workforce-development-framework">Public mental health leadership and workforce development framework</a></li>
+
+  </ul>
+</nav>
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-collections-9de1db80" data-module="gem-toggle">
+
+    <h3 id="related-nav-collections-9de1db80" class="gem-c-related-navigation__sub-heading gem-c-related-navigation__sub-heading--sidebar" data-track-count="sidebarRelatedItemSection">Collection</h3>
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar" data-track-category="relatedLinkClicked" data-track-action="2.1 Collection" data-track-label="/government/collections/prevention-concordat-for-better-mental-health" data-track-options='{"dimension28":"1","dimension29":"Prevention concordat for better mental health"}' href="/government/collections/prevention-concordat-for-better-mental-health">Prevention concordat for better mental health</a></li>
+
+  </ul>
+</nav>
+
+  </div>
+
+
+</div>
+
+</div>
+
+</div>
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+  <div class="gem-c-contextual-footer">
+
+  <div class="gem-c-related-navigation">
+
+
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-topics-14c74e13" data-module="gem-toggle">
+
+    <h2 id="related-nav-topics-14c74e13" class="gem-c-related-navigation__sub-heading gem-c-related-navigation__sub-heading--footer" data-track-count="footerRelatedItemSection">Explore the topic</h2>
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" data-track-category="relatedLinkClicked" data-track-action="1.1 Explore the topic" data-track-label="/health-and-social-care/mental-health" data-track-options='{"dimension28":"1","dimension29":"Mental health"}' href="/health-and-social-care/mental-health">Mental health</a></li>
+
+  </ul>
+</nav>
+
+  </div>
+
+  </div>
+
+
+    </div>
+  </div>
+
+
+    </main>
+
+<div class="gem-c-feedback gem-c-feedback--top-margin" data-module="feedback">
+
+<div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
+  <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
+    <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
+
+    <a class="gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" role="button" style="display: none;" hidden="hidden" aria-hidden="true" href="/contact/govuk">
+      Maybe
+</a>
+    <a class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" aria-expanded="false" role="button" href="/contact/govuk">
+      Yes <span class="visually-hidden">this page is useful</span>
+</a>
+    <a class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" role="button" href="/contact/govuk">
+      No <span class="visually-hidden">this page is not useful</span>
+</a>
+    <a class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" role="button" href="/contact/govuk">
+      Is there anything wrong with this page?
+</a>  </div>
+
+  <div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+    Thank you for your feedback
+  </div>
+</div>
+
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" method="post">
+  <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+
+      <input type="hidden" name="url" value="https://www.gov.uk/government/publications/prevention-concordat-for-better-mental-health-consensus-statement">
+
+      <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+      <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
+
+
+<div class="govuk-form-group">
+
+<label for="input-ebbbf392" class="gem-c-label govuk-label">
+  What were you doing?
+</label>
+
+
+
+
+  <input name="what_doing" class="gem-c-input govuk-input" id="input-ebbbf392" type="text" aria-describedby="feedback_explanation">
+</div>
+
+
+<div class="govuk-form-group">
+
+<label for="input-bd10906e" class="gem-c-label govuk-label">
+  What went wrong?
+</label>
+
+
+
+
+  <input name="what_wrong" class="gem-c-input govuk-input" id="input-bd10906e" type="text">
+</div>
+
+
+
+
+  <button class="gem-c-button govuk-button" type="submit">Send</button>
+
+
+    </div>
+  </div>
+</form>
+
+  <form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form" method="post">
+  <a href="#" class="gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" id="survey-wrapper">
+      <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+
+      <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
+      <input name="email_survey_signup[survey_source]" type="hidden" value="/government/publications/prevention-concordat-for-better-mental-health-consensus-statement">
+
+      <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+      <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
+
+
+<div class="govuk-form-group">
+
+<label for="input-108e9d93" class="gem-c-label govuk-label">
+  Email address
+</label>
+
+
+
+
+  <input name="email_survey_signup[email_address]" class="gem-c-input govuk-input" id="input-108e9d93" type="email" autocomplete="email" aria-describedby="survey_explanation">
+</div>
+
+
+
+
+  <button class="gem-c-button govuk-button" type="submit">Send me the survey</button>
+
+
+    </div>
+  </div>
+</form>
+
+</div>
+
+  </div>
+
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+            <div class="footer-categories" data-module="track-click">
+      <div class="footer-explore">
+        <h2>Brexit</h2>
+        <ul>
+          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Get ready for Brexit" href="/brexit">Get ready for Brexit</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-categories" data-module="track-click">
+      <div class="footer-explore">
+        <h2>Services and information</h2>
+
+        <ul>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Benefits" href="/browse/benefits">Benefits</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Births, deaths, marriages and care" href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Business and self-employed" href="/browse/business">Business and self-employed</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="" href="/browse/childcare-parenting">Childcare and parenting</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Citizenship and living in the UK" href="/browse/citizenship">Citizenship and living in the UK</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Crime, justice and the law" href="/browse/justice">Crime, justice and the law</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Disabled people" href="/browse/disabilities">Disabled people</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Driving and transport" href="/browse/driving">Driving and transport</a></li>
+        </ul>
+        <ul>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Education and learning" href="/browse/education">Education and learning</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Employing people" href="/browse/employing-people">Employing people</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Environment and countryside" href="/browse/environment-countryside">Environment and countryside</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Housing and local services" href="/browse/housing-local-services">Housing and local services</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Money and tax" href="/browse/tax">Money and tax</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Passports, travel and living abroad" href="/browse/abroad">Passports, travel and living abroad</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Visas and immigration" href="/browse/visas-immigration">Visas and immigration</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Working, jobs and pensions" href="/browse/working">Working, jobs and pensions</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-inside-government">
+        <h2>Departments and policy</h2>
+
+        <ul>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="How government works" href="/government/how-government-works">How government works</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Departments" href="/government/organisations">Departments</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Worldwide" href="/world">Worldwide</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Services" href="/search/services">Services</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Guidance and regulation" href="/search/guidance-and-regulation">Guidance and regulation</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="News and communications" href="/search/news-and-communications">News and communications</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Research and statistics" href="/search/research-and-statistics">Research and statistics</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Policy papers and consultations" href="/search/policy-papers-and-consultations">Policy papers and consultations</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Transparency and freedom of information releases" href="/search/transparency-and-freedom-of-information-releases">Transparency and freedom of information releases</a></li>
+        </ul>
+      </div>
+      <hr>
+    </div>
+
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+              <h2 class="visuallyhidden">Support links</h2>
+<ul>
+  <li><a href="/help">Help</a></li>
+  <li><a href="/help/cookies">Cookies</a></li>
+  <li><a href="/contact">Contact</a></li>
+  <li><a href="/help/accessibility">Accessibility</a></li>
+  <li><a href="/help/terms-conditions">Terms and conditions</a></li>
+  <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
+  <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+</li>
+</ul>
+
+
+
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+                <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+      <script src="https://assets.publishing.service.gov.uk/static/libs/jquery/jquery-1.12.4-c731c20e2995c576b0509d3bd776f7ab64a66b95363a3b5fae9864299ee594ed.js" crossorigin="anonymous" integrity="sha256-xzHCDimVxXawUJ0713b3q2Sma5U2OjtfrphkKZ7llO0="></script>
+<script src="https://assets.publishing.service.gov.uk/static/header-footer-only-df9bc75f675d7efc41b6922cdd5bee7ef969c472bb9b9b7b04285dd042603ea3.js" crossorigin="anonymous" integrity="sha256-35vHX2ddfvxBtpIs3VvufvlpxHK7m5t7BChd0EJgPqM="></script>
+<script src="https://assets.publishing.service.gov.uk/static/surveys-61e9061a16a39f1d56569e259152b609c81570e1e642c96515370852250364bb.js" crossorigin="anonymous" integrity="sha256-YekGGhajnx1WVp4lkVK2CcgVcOHmQsllFTcIUiUDZLs="></script>
+
+
+
+    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+  <script src="https://assets.publishing.service.gov.uk/government-frontend/application-d8e79c88633a239b801642396be8097e013230b5df84db7bfed9750712bd2c30.js" crossorigin="anonymous" integrity="sha256-2OeciGM6I5uAFkI5a+gJfgEyMLXfhNt7/tl1BxK9LDA="></script><script type="application/ld+json">
+  {"@context":"http://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.gov.uk/government/publications/prevention-concordat-for-better-mental-health-consensus-statement"},"headline":"Prevention concordat for better mental health: consensus statement","datePublished":"2017-08-30T08:30:00.000+00:00","dateModified":"2019-09-09T10:16:44.000+00:00","description":"Describes the consensus statement of the prevention concordat for better mental health and lists the signatories.","publisher":{"@type":"Organization","name":"GOV.UK","url":"https://www.gov.uk","logo":{"@type":"ImageObject","url":"https://assets.publishing.service.gov.uk/government-frontend/govuk_publishing_components/govuk-logo-e5962881254c9adb48f94d2f627d3bb67f258a6cbccc969e80abb7bbe4622976.png"}},"image":["https://assets.publishing.service.gov.uk/government-frontend/govuk_publishing_components/govuk-schema-placeholder-1x1-5ceffac04f7f6d4f421bd1d36dbb723ef48c15426d7f77f90be80a83af3c747e.png","https://assets.publishing.service.gov.uk/government-frontend/govuk_publishing_components/govuk-schema-placeholder-4x3-fcfe16abb1a015848e50d2ea797666a9eaf5158dca38ddfb1e52dc8c0543ab74.png","https://assets.publishing.service.gov.uk/government-frontend/govuk_publishing_components/govuk-schema-placeholder-16x9-fcf616879a7b37970df4d2117de962e08f7d057674ef1af6063dcdd529424eee.png"],"author":{"@type":"Organization","name":"Public Health England","url":"https://www.gov.uk/government/organisations/public-health-england"},"isPartOf":[{"@context":"http://schema.org","@type":"CreativeWork","sameAs":"https://www.gov.uk/government/collections/prevention-concordat-for-better-mental-health"}],"about":[{"@context":"http://schema.org","@type":"Thing","sameAs":"https://www.gov.uk/health-and-social-care/mental-health"}],"articleBody":"\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eThis document:\u003c/p\u003e\n\n\u003cul\u003e\n  \u003cli\u003eexplains the prevention concordat for better mental health\u003c/li\u003e\n  \u003cli\u003edescribes the shared commitment of the organisations involved\u003c/li\u003e\n  \u003cli\u003eprovides a list of all signatory organisations\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/div\u003e"}
+</script><script type="application/ld+json">
+  {"@context":"http://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"name":"Home","@id":"https://www.gov.uk/"}}]}
+</script>
 </body>
 </html>

--- a/policytool/scraper/tests/test_gov_spider.py
+++ b/policytool/scraper/tests/test_gov_spider.py
@@ -76,7 +76,7 @@ class TestGovSpider(unittest.TestCase):
             self.assertTrue(res)
 
             # Check the name of the function called in callback
-            self.assertEqual(res.callback.__name__, 'parse')
+            self.assertEqual(res.callback.__name__, 'parse_article')
 
     def test_parse_article(self):
         """Test if given an publication listing page of the who website,
@@ -92,7 +92,7 @@ class TestGovSpider(unittest.TestCase):
                 request=request
             )
 
-            res = next(self.spider.parse(response))
+            res = next(self.spider.parse_article(response))
 
             # Check if something is returned
             self.assertTrue(res)

--- a/policytool/scraper/wsf_scraping/settings.py
+++ b/policytool/scraper/wsf_scraping/settings.py
@@ -28,7 +28,7 @@ LOG_FORMATTER = 'policytool.scraper.wsf_scraping.middlewares.PoliteLogFormatter'
 # Set pdfminer log to WARNING
 logging.getLogger("pdfminer").setLevel(logging.WARNING)
 
-DUPEFILTER_CLASS = 'scrapy.dupefilters.BaseDupeFilter'
+DUPEFILTER_CLASS = 'scrapy.dupefilters.RFPDupeFilter'
 # Use a physicqal queue, slower but add fiability
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'


### PR DESCRIPTION
# Description

Gov.uk spider wasn't writting anything, neither into pdfs nor into the manifest. This PR aims to fix that by the following fixes:

 - Fix the css classes used to find the pdf urls
 - Switch the dupefilter class to something that actually filters
 - Update gov_uk spider's tests

See issue: #200 For more information

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make test`
`make docker-test`
Local runs on MacOS 10.14.6 - Docker / Docker Compose