### PR TITLE
elastic: reduce fulltext memory usage to <800MB

### DIFF
--- a/policytool/elastic/epmc_metadata.py
+++ b/policytool/elastic/epmc_metadata.py
@@ -12,6 +12,7 @@ import logging
 from . import common
 
 ES_INDEX = 'epmc-metadata'
+CHUNK_SIZE = 1000  # tuned for small(ish) size of pub metadata
 
 def to_es_action(line):
     d = json.loads(line)
@@ -42,6 +43,7 @@ def insert_file(f, es, max_items=None):
     return common.insert_actions(
         es,
         common.yield_actions(f, to_es_action, max_items),
+        CHUNK_SIZE,
         )
 
 

--- a/policytool/elastic/fulltext_docs.py
+++ b/policytool/elastic/fulltext_docs.py
@@ -13,7 +13,7 @@ import logging
 from . import common
 
 ES_INDEX = 'datalabs-fulltext'
-
+CHUNK_SIZE = 50  # tuned for large(ish) size of policy docs
 
 def to_es_action(org, line):
     """ Returns a preformated line to add to an Elasticsearch bulk query. """
@@ -51,6 +51,7 @@ def insert_file(f, es, org, max_items=None):
     return common.insert_actions(
         es,
         common.yield_actions(f, to_es_func, max_items),
+        CHUNK_SIZE,
         )
 
 


### PR DESCRIPTION
# Description

`policytool.elastic.fulltext_docs.insert_file()` was using >2GB RAM when
inserting WHO publications into ES in staging. To fix this:

* Use a smaller chunk size for inserting full text documents into ES
  than for inserting EPMC publication metadata. This makes it so
  that the chunks of "actions" can be tuned by total memory used
  instsead of just number of items, whether small or large.
* Similarly, tune the memory that can be accumulated by any
  ES insert thread pool using number of chunks (which are scaled
  to memory) instead of raw number of items (which are not).

Issue: https://github.com/wellcometrust/policytool/issues/231

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

1. `./docker_exec.sh airflow test policy ESIndexFulltextDocs.who_iris` while monitoring memory usage with `docker stats`
1. `make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
