### PR TITLE
Use single index for policy docs; add cli

### DIFF
--- a/policytool/airflow/dags/policy.py
+++ b/policytool/airflow/dags/policy.py
@@ -108,7 +108,7 @@ def create_org_pipeline(dag, organisation, item_limits, spider_years):
         organisation=organisation,
         es_host='elasticsearch',
         item_limits=item_limits.index,
-        es_index='-'.join([dag.dag_id, 'fulltext', organisation]),
+        es_index='-'.join([dag.dag_id, 'policy-docs']),
         dag=dag
     )
 

--- a/policytool/elastic/common.py
+++ b/policytool/elastic/common.py
@@ -204,3 +204,11 @@ def insert_from_argv(description, clean_es, insert_file):
     else:
         with open(args.input, 'rb') as f:
             return insert_file(f, es, args.max_items)
+
+
+if __name__ == '__main__':
+    parser = create_argument_parser(
+        'Instantiates ES client for use with python -i')
+    args = parser.parse_args()
+
+    es = es_from_args(args)


### PR DESCRIPTION
# Description

Two small changes:

1. Use the same index name for all policy documents we index.
1. Add a minimal CLI for obtaining an ElasticSearch client, via `python -i -m policytool.elastic.common`

## Type of change

(feature?)

# How Has This Been Tested?

1. Running test & main DAG on EC2 instance.
1. `make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] New and existing unit tests pass locally with my changes
