### PR TITLE
airflow: fix fuzzy match when no refs to match

### DIFF
--- a/policytool/airflow/tasks/fuzzy_match_refs.py
+++ b/policytool/airflow/tasks/fuzzy_match_refs.py
@@ -153,6 +153,7 @@ class FuzzyMatchRefsOperator(BaseOperator):
             with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
                 refs = yield_structured_references(s3, self.src_s3_key)
                 match_count = 0
+                count = 0
                 for count, structured_reference in enumerate(refs, 1):
                     if count % 500 == 0:
                         logger.info(


### PR DESCRIPTION
# Description

Fix cases where there are no references to match, such as we see when
running the test DAG in staging.

Issue: https://github.com/wellcometrust/policytool/issues/241

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] New and existing unit tests pass locally with my changes
