### PR TITLE
Update refparse scraped JSON example in README to one that will work

### DIFF
--- a/policytool/refparse/README.md
+++ b/policytool/refparse/README.md
@@ -12,7 +12,7 @@ arguments of your file locations. E.g., from the main `policytool` directory, ru
 mkdir -p ./tmp/parser-output/output_folder_name
 
 python -m policytool.refparse.refparse \
-    --scraper-file "s3://datalabs-data/scraper-results/msf/20190117.json" \
+    --scraper-file "s3://datalabs-dev/reach-airflow/output/policy/parsed-pdfs/msf/parsed-pdfs-msf.json.gz" \
     --references-file "s3://datalabs-data/wellcome_publications/uber_api_publications.csv" \
     --model-file "s3://datalabs-data/reference_parser_models/reference_parser_pipeline.pkl" \
     --output-url "file://./tmp/parser-output/output_folder_name"


### PR DESCRIPTION
Very small change to scraped data location.
Fixes issue #193

# How Has This Been Tested?

Running the new command in the virtualenv worked and started to parse and match the references (before I quit it).

