### PR TITLE
Index citations from fuzzy matcher

### DIFF
--- a/policytool/airflow/tasks/es_index_fuzzy_matched.py
+++ b/policytool/airflow/tasks/es_index_fuzzy_matched.py
@@ -1,0 +1,76 @@
+"""
+Operator to index the latest fuzzy matched citations from AWS S3 to
+Elasticsearch.
+"""
+
+import tempfile
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from policytool.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
+from policytool.elastic import fuzzy_matched_citations
+import policytool.elastic.common
+
+
+class ESIndexFuzzyMatchedCitations(BaseOperator):
+    """ Download fuzzy matched citations stored in S3 and index them with
+    Elasticsearch.
+    """
+
+    template_fields = (
+        'src_s3_key',
+    )
+
+    @apply_defaults
+    def __init__(self, src_s3_key, es_host, organisation,  es_port=9200,
+                 item_limits=None, aws_conn_id='aws_default',
+                 es_index=None, *args, **kwargs):
+        """
+        Args:
+            src_s3_key: S3 URL for the json.gz output file.
+            es_host: the hostname of elasticsearch database.
+            es_port: the port of elasticsearch database. Default to 9200.
+            item_limits: Maximum number of citations to process.
+            aws_conn_id: Aws connection name.
+        """
+
+        super().__init__(*args, **kwargs)
+
+        if not src_s3_key.endswith('.json.gz'):
+            raise ValueError('src_s3_key must end in .json.gz')
+
+        self.src_s3_key = src_s3_key
+        self.es_host = es_host
+        self.es_port = es_port
+        self.aws_conn_id = aws_conn_id
+        self.item_limits = item_limits
+        self.es_index = es_index
+        self.organisation = organisation
+
+    def execute(self, context):
+        es = policytool.elastic.common.connect(
+            self.es_host, self.es_port)
+        s3 = WellcomeS3Hook()
+
+        # TODO: implement skipping mechanism
+        fuzzy_matched_citations.clean_es(es, self.es_index)
+
+        self.log.info(
+            'Getting %s pubs from %s',
+            self.item_limits if self.item_limits else 'all',
+            self.src_s3_key,
+        )
+
+        s3_object = s3.get_key(self.src_s3_key)
+        with tempfile.NamedTemporaryFile() as tf:
+            s3_object.download_fileobj(tf)
+            tf.seek(0)
+            count = fuzzy_matched_citations.insert_file(
+                tf,
+                es,
+                org=self.organisation,
+                max_items=self.item_limits,
+                es_index=self.es_index,
+            )
+        self.log.info('execute: insert complete count=%d', count)

--- a/policytool/elastic/fulltext_docs.py
+++ b/policytool/elastic/fulltext_docs.py
@@ -35,7 +35,8 @@ def clean_es(es, es_index):
 
 def insert_file(f, es, org, es_index, max_items=None):
     """
-    Inserts EPMC metadata from a json.gz file into Elasticsearch.
+    Inserts the policy documents' fulltexts from a json.gz file
+    into Elasticsearch.
 
     Args:
         f: json.gz file object

--- a/policytool/elastic/fuzzy_matched_citations.py
+++ b/policytool/elastic/fuzzy_matched_citations.py
@@ -12,19 +12,22 @@ import logging
 
 from . import common
 
-# TODO: Check that size for citations
-CHUNK_SIZE = 50
+CHUNK_SIZE = 1000  # Tuned for small citation metadata
 
 
 def to_es_action(org, es_index, line):
     """ Returns a preformated line to add to an Elasticsearch bulk query. """
     d = json.loads(line)
+
     return {
         "_index": es_index,
         "doc": {
-            'hash': d['file_hash'],
-            'text': d['text'],
-            'organisation': org,
+            'Document id': d['Document id'],
+            'Reference id': d['Reference id'],
+            'Extracted title': d['Extracted title'],
+            'Matched title': d['Matched title'],
+            'Similarity': d['Similarity'],
+            'Match algorithm': d['Match algorithm'],
         }
     }
 

--- a/policytool/elastic/fuzzy_matched_citations.py
+++ b/policytool/elastic/fuzzy_matched_citations.py
@@ -1,0 +1,67 @@
+"""
+Inserts fuzzy-matched citations into Elasticsearch.
+
+Sample URL for testing:
+
+    s3://datalabs-staging/reach-airflow/output/policy-test/fuzzy-matched-refs/nice/fuzzy-matched-refs-nice.json.gz
+"""
+
+import functools
+import json
+import logging
+
+from . import common
+
+# TODO: Check that size for citations
+CHUNK_SIZE = 50
+
+
+def to_es_action(org, es_index, line):
+    """ Returns a preformated line to add to an Elasticsearch bulk query. """
+    d = json.loads(line)
+    return {
+        "_index": es_index,
+        "doc": {
+            'hash': d['file_hash'],
+            'text': d['text'],
+            'organisation': org,
+        }
+    }
+
+
+def clean_es(es, es_index):
+    """ Ensure an empty index exists. """
+    common.clean_es(es, es_index)
+
+
+def insert_file(f, es, org, es_index, max_items=None):
+    """
+    Inserts fuzzy matched citations from a json.gz file into Elasticsearch.
+
+    Args:
+        f: json.gz file object
+        es: a living connection to elacticsearch
+        org: organization name associated with the doc
+        max_items: maximum number of records to insert, or None
+    """
+
+    logging.info(
+        'fuzzymatched_citations.insert_file: f=%s es=%s max_items=%s',
+        f, es, max_items)
+    to_es_func = functools.partial(to_es_action, org, es_index)
+    return common.insert_actions(
+        es,
+        common.yield_actions(f, to_es_func, max_items),
+        CHUNK_SIZE,
+        )
+
+
+if __name__ == '__main__':
+    def insert_func(f, es, max_items=None):
+        return insert_file(f, es, 'unknown', 'policy-test-fuzzymatched',
+                           max_items=max_items)
+
+    count = common.insert_from_argv(
+        __doc__.strip(), clean_es, insert_func)
+
+    logging.info('Imported %d pubs into ES', count)


### PR DESCRIPTION
# Description

This PR adds the indexion of all citation matched in the fuzzy matching task of the airflow pipeline.

 - Adds `fuzzy_matched_citations.py` to the elastic module
 - Adds `es_index_fuzzy_matched.py` to the airflow tasks
 - Adds the task to the main and test DAG
 - Fix an incoherence in elastic's `fulltext_docs.py`

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

`make docker-test`
Local runs using Docker with 2CPU, 10.5GiB memory:
 - policy-test ✅ 
 - policy ✅ 
