### PR TITLE
Add urls back to the manifest file

### DIFF
--- a/policytool/scraper/wsf_scraping/file_system.py
+++ b/policytool/scraper/wsf_scraping/file_system.py
@@ -132,6 +132,7 @@ class S3FileSystem(FileSystem):
 
         # If the manifest has no content yet, let's create it
         content = current_manifest.get('content', {})
+        data = current_manifest.get('data', {})
         for row in data_file:
             item = json.loads(row)
             hash_list = content.get(item['hash'][:2], None)
@@ -140,6 +141,9 @@ class S3FileSystem(FileSystem):
                     hash_list.append(item['hash'])
             else:
                 content[item['hash'][:2]] = [item['hash']]
+
+            if not data.get(item['hash']):
+                data[item['hash']] = {'url': item['url']}
 
         key = os.path.join(
             self.prefix,
@@ -151,7 +155,7 @@ class S3FileSystem(FileSystem):
             Bucket=self.bucket,
             Key=key,
             Body=json.dumps(
-                {'metadata': metadata, 'content': content}
+                {'metadata': metadata, 'content': content, 'data': data}
             ).encode('utf-8')
         )
 

--- a/policytool/scraper/wsf_scraping/items.py
+++ b/policytool/scraper/wsf_scraping/items.py
@@ -6,12 +6,12 @@ class Article(scrapy.Item):
     def __repr__(self):
         return repr({
             'title': self.get('title'),
-            'uri': self.get('uri'),
+            'url': self.get('uri'),
         })
 
     title = scrapy.Field()
     year = scrapy.Field()
-    uri = scrapy.Field()
+    url = scrapy.Field()
     pdf = scrapy.Field()
     hash = scrapy.Field()
     has_text = scrapy.Field()

--- a/policytool/scraper/wsf_scraping/items.py
+++ b/policytool/scraper/wsf_scraping/items.py
@@ -6,7 +6,7 @@ class Article(scrapy.Item):
     def __repr__(self):
         return repr({
             'title': self.get('title'),
-            'url': self.get('uri'),
+            'url': self.get('url'),
         })
 
     title = scrapy.Field()

--- a/policytool/scraper/wsf_scraping/spiders/base_spider.py
+++ b/policytool/scraper/wsf_scraping/spiders/base_spider.py
@@ -99,7 +99,7 @@ class BaseSpider(scrapy.Spider):
 
         article = Article({
             'title': data_dict.get('title'),
-            'uri': response.request.url,
+            'url': response.request.url,
             'year': data_dict.get('year'),
             'authors': data_dict.get('authors'),
             'types': data_dict.get('types'),


### PR DESCRIPTION
# Description
The lack of url attribute is blocking right now (#244 ) so this PR adds a 'data' section to the manifest file as a temporary fix.
This is non-optimal and need changes, as it duplicates the file_hash as dict key. On the other hand, it doesn't affect anything else on the DAG so everything else can run normally.

Fix #244 

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?
`make docker-test`
Local runs on Docker with 2CPU, 10.5GiB:
 - `./docker_exec.sh airflow test policy-test Spider.msf 2019-10-02`
 - Verification of the produced json file

