### PR TITLE
Fix parliament scraping

### DIFF
--- a/policytool/scraper/wsf_scraping/spiders/parliament_spider.py
+++ b/policytool/scraper/wsf_scraping/spiders/parliament_spider.py
@@ -105,7 +105,10 @@ class ParliamentSpider(BaseSpider):
                 callback=self.save_pdf,
                 errback=self.on_error,
             )
-        else:
+        elif self._check_headers(
+            response.headers,
+            b'text/html',
+        ):
             for href in response.css('a::attr(href)').extract():
                 if href.endswith('pdf'):
                     yield Request(
@@ -118,3 +121,4 @@ class ParliamentSpider(BaseSpider):
                         callback=self.save_pdf,
                         errback=self.on_error,
                     )
+        yield

--- a/policytool/scraper/wsf_scraping/spiders/parliament_spider.py
+++ b/policytool/scraper/wsf_scraping/spiders/parliament_spider.py
@@ -15,23 +15,26 @@ class ParliamentSpider(BaseSpider):
         """This sets up the initial urls."""
 
         query_list = [
-            'Parameters.Fields.all=',
-            'Parameters.Fields.all-target=',
-            'Parameters.Fields.phrase=',
-            'Parameters.Fields.phrase-target=',
-            'Parameters.Fields.any=',
-            'Parameters.Fields.any-target=',
-            'Parameters.Fields.exclude=',
-            'Parameters.Fields.exclude-target=',
-            'Parameters.Fields.house=House+of+Commons',
-            'Parameters.Fields.house=House+of+Lords',
-            'Parameters.Fields.member=',
-            'Parameters.Fields.subject=',
-            'Parameters.Fields.reference=',
-            'When%3A=date',
-            'Parameters.Fields.date=01%2F01%2F1980',
-            'Parameters.Fields.date=04%2F10%2F2018',
-            'Parameters.PageSize=100'
+            "Parameters.Fields.all=",
+            "Parameters.Fields.all-target=",
+            "Parameters.Fields.phrase=",
+            "Parameters.Fields.phrase-target=",
+            "Parameters.Fields.any=",
+            "Parameters.Fields.any-target=",
+            "Parameters.Fields.exclude=",
+            "Parameters.Fields.exclude-target=",
+            "Parameters.Fields.type=Bills",
+            "Parameters.Fields.type=Select+Committee+reports",
+            "Parameters.Fields.type=Select+Committee+written+evidence",
+            "Parameters.Fields.type=Debates",
+            "Parameters.Fields.type=Research+briefings",
+            "Parameters.Fields.member=",
+            "Parameters.Fields.subject=",
+            "Parameters.Fields.reference=",
+            "When%3A=date",
+            "Parameters.Fields.date=01%2F01%2F1980",
+            "Parameters.Fields.date=04%2F10%2F2018",
+            "Parameters.PageSize=100"
         ]
         base_url = 'http://search-material.parliament.uk/search'
         query_params = '&'.join(query_list)


### PR DESCRIPTION
# Description

Parliament scraping has been crashing before it finishes lately, because of the huge number of publication it's trying to pull. Most of those publications are not useful to us, so considering that, we decided to limit what gets scraped from the parliament website.

In addition to that, this PR also fixes a bug where the parliament spider only checked for pdf header, and ended up trying to get the css atribute of `.doc` or `.xls` documents.

 - gov_uk spider: Update the search url (fix #226 )
 - gov_uk spider: Check if the reponse is a text response (Fix #222 )

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make docker-test`
Local runs on Docker with 2CPU 10.5GiB:
```
./docker_exec.sh airflow test policy Spider.parliament 2019-10-03
```
