### PR TITLE
Fix robots.txt reporting to sentry

### DIFF
--- a/policytool/scraper/wsf_scraping/spiders/base_spider.py
+++ b/policytool/scraper/wsf_scraping/spiders/base_spider.py
@@ -1,7 +1,7 @@
 import os.path
 import tempfile
 
-from scrapy.exceptions import CloseSpider
+from scrapy.exceptions import CloseSpider, IgnoreRequest
 from scrapy.spidermiddlewares.httperror import HttpError
 from scrapy.utils.project import get_project_settings
 from twisted.internet.error import DNSLookupError
@@ -42,6 +42,11 @@ class BaseSpider(scrapy.Spider):
         elif failure.check(TimeoutError):
             request = failure.request
             self.logger.warning('TimeoutError on %s', request.url)
+
+        # Catch the case where robots.txt files forbid a page
+        elif failure.check(IgnoreRequest):
+            request = failure.request
+            self.logger.warning('Robots.txt forbidden on %s', request.url)
 
         else:
             self.logger.error(repr(failure))


### PR DESCRIPTION
# Description

Requests forbidden by robots.txt iles where wrongly logged into sentry. This commit filter them and treat them as warnings.

Fix #191 

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

```
make docker-test
```
Local runs using Docker with 2CPU and 10.5GiB:
```
./docker_exec.sh airflow test policy Spider.unicef 2019-10-07
```
(On a new scrape, UNICEF has 4 robots.txt forbidden requests right at the beginning)

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
